### PR TITLE
57 import from geff in addition to csv

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies =[
     "psygnal",
     "scikit-image",
     "geff",
+    "dask",
 ]
 [project.optional-dependencies]
 testing =["pytest", "pytest-cov"]

--- a/src/funtracks/data_model/solution_tracks.py
+++ b/src/funtracks/data_model/solution_tracks.py
@@ -38,8 +38,11 @@ class SolutionTracks(Tracks):
         )
         self.max_track_id: int
 
-        # double check
-        has_track_id = NodeAttr.TRACK_ID.value in graph.nodes[next(iter(graph.nodes))]
+        # recompute track_id if requested or missing
+        if graph.number_of_nodes() == 0:
+            has_track_id = False
+        else:
+            has_track_id = NodeAttr.TRACK_ID.value in graph.nodes[next(iter(graph.nodes))]
         if recompute_track_ids or not has_track_id:
             self._initialize_track_ids()
 

--- a/src/funtracks/data_model/solution_tracks.py
+++ b/src/funtracks/data_model/solution_tracks.py
@@ -26,6 +26,7 @@ class SolutionTracks(Tracks):
         pos_attr: str | tuple[str] | list[str] = NodeAttr.POS.value,
         scale: list[float] | None = None,
         ndim: int | None = None,
+        recompute_track_ids: bool = True,
     ):
         super().__init__(
             graph,
@@ -36,7 +37,11 @@ class SolutionTracks(Tracks):
             ndim=ndim,
         )
         self.max_track_id: int
-        self._initialize_track_ids()
+
+        # double check
+        has_track_id = NodeAttr.TRACK_ID.value in graph.nodes[next(iter(graph.nodes))]
+        if recompute_track_ids or not has_track_id:
+            self._initialize_track_ids()
 
     @classmethod
     def from_tracks(cls, tracks: Tracks):

--- a/src/funtracks/import_export/import_from_geff.py
+++ b/src/funtracks/import_export/import_from_geff.py
@@ -238,6 +238,7 @@ def import_from_geff(
     if name_map.get(NodeAttr.TRACK_ID.value) is not None:
         for _, data in graph.nodes(data=True):
             data[NodeAttr.TRACK_ID.value] = data.pop(name_map[NodeAttr.TRACK_ID.value])
+    recompute_track_ids = NodeAttr.TRACK_ID.value not in selected_attrs
 
     # Add optional extra features.
     if extra_features is None:
@@ -263,6 +264,7 @@ def import_from_geff(
         time_attr=time_attr,
         ndim=ndims,
         scale=scale,
+        recompute_track_ids=recompute_track_ids,
     )
     # compute the 'area' attribute if needed
     if tracks.segmentation is not None and extra_features.get("area"):

--- a/src/funtracks/import_export/import_from_geff.py
+++ b/src/funtracks/import_export/import_from_geff.py
@@ -233,26 +233,19 @@ def import_from_geff(
                 )
             segmentation = relabel_seg_id_to_node_id(times, ids, seg_ids, segmentation)
 
+    # Add optional extra features.
+    if extra_features is None:
+        extra_features = {}
+    selected_attrs.extend(extra_features.keys())
+
     # All pre-checks have passed, load the graph now.
-    graph, _ = geff.read_nx(directory)
+    graph, _ = geff.read_nx(directory, node_props=selected_attrs)
 
     # Relabel track_id attr to NodeAttr.TRACK_ID.value.
     if name_map.get(NodeAttr.TRACK_ID.value) is not None:
         for _, data in graph.nodes(data=True):
             data[NodeAttr.TRACK_ID.value] = data.pop(name_map[NodeAttr.TRACK_ID.value])
     recompute_track_ids = NodeAttr.TRACK_ID.value not in selected_attrs
-
-    # Add optional extra features.
-    if extra_features is None:
-        extra_features = {}
-    selected_attrs.extend(extra_features.keys())
-
-    # Drop all node attributes not in selected_attrs.
-    for node in graph.nodes:
-        attrs = graph.nodes[node]
-        for key in list(attrs.keys()):
-            if key not in selected_attrs:
-                del attrs[key]
 
     # Put segmentation data in memory now.
     if segmentation is not None and isinstance(segmentation, da.Array):

--- a/src/funtracks/import_export/import_from_geff.py
+++ b/src/funtracks/import_export/import_from_geff.py
@@ -182,13 +182,13 @@ def import_from_geff(
                     f"- {e}" for e in errors
                 )
                 raise ValueError(error_msg)
-            seg_id = group["nodes"]["props"][name_map[NodeAttr.SEG_ID.value]]["values"][
-                -1
-            ]
+            seg_id = int(
+                group["nodes"]["props"][name_map[NodeAttr.SEG_ID.value]]["values"][-1]
+            )
         else:
             # assign the node id as seg_id instead and check in the next step if this is
             #  valid.
-            seg_id = group["nodes"]["ids"][-1]
+            seg_id = int(group["nodes"]["ids"][-1])
 
         # Get the coordinates for the last node.
         t = group["nodes"]["props"][name_map[NodeAttr.TIME.value]]["values"][-1]

--- a/src/funtracks/import_export/import_from_geff.py
+++ b/src/funtracks/import_export/import_from_geff.py
@@ -7,9 +7,6 @@ from typing import (
 import geff
 import numpy as np
 import zarr
-from finn_builtins.io._read import (
-    magic_imread,
-)
 from geff.affine import Affine
 from geff.validators.segmentation_validators import (
     axes_match_seg_dims,
@@ -20,6 +17,7 @@ from geff.validators.validators import validate_lineages, validate_tracklets
 from numpy.typing import ArrayLike
 
 from funtracks.data_model.graph_attributes import NodeAttr
+from funtracks.import_export.magic_imread import magic_imread
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -57,7 +55,7 @@ def relabel_seg_id_to_node_id(
 def import_from_geff(
     directory: Path,
     name_map: dict[str, str],
-    segmentation: Path | None = None,
+    segmentation_path: Path | None = None,
     scale: list[float] | None = None,
     extra_features: dict[str, bool] | None = None,
 ):
@@ -84,7 +82,7 @@ def import_from_geff(
                 (seg_id), if a segmentation is provided
                 (tracklet_id), optional, if it is a solution
                 (lineage_id), optional, if it is a solution
-        segmentation (Path | None = None): (Relative) path to segmentation data.
+        segmentation_path (Path | None = None): (Relative) path to segmentation data.
         scale (list[float]): scaling information (pixel to world coordinates).
         extra_features (dict[str: bool] | None=None): optional features to include in the
             Tracks object. The keys are the feature names, and the boolean value indicates
@@ -160,9 +158,9 @@ def import_from_geff(
             selected_attrs.append(name_map["lineage_id"])
 
     # Try to load the segmentation data, if it was provided.
-    if segmentation is not None:
+    if segmentation_path is not None:
         segmentation = magic_imread(
-            segmentation, use_dask=True
+            segmentation_path, use_dask=True
         )  # change to in memory later
 
         # check if the axes information in the metadata matches the segmentation

--- a/src/funtracks/import_export/import_from_geff.py
+++ b/src/funtracks/import_export/import_from_geff.py
@@ -221,9 +221,11 @@ def import_from_geff(
         # If the provided segmentation has seg ids that are not identical to node ids,
         # relabel it now.
         if group["nodes"]["ids"][-1] != seg_id:
-            times = group["nodes"]["props"][name_map[NodeAttr.TIME.value]]["values"]
-            ids = group["nodes"]["ids"]
-            seg_ids = group["nodes"]["props"][name_map[NodeAttr.SEG_ID.value]]["values"]
+            times = group["nodes"]["props"][name_map[NodeAttr.TIME.value]]["values"][:]
+            ids = group["nodes"]["ids"][:]
+            seg_ids = group["nodes"]["props"][name_map[NodeAttr.SEG_ID.value]]["values"][
+                :
+            ]
 
             if not len(times) == len(ids) == len(seg_ids):
                 raise ValueError(

--- a/src/funtracks/import_export/import_from_geff.py
+++ b/src/funtracks/import_export/import_from_geff.py
@@ -1,0 +1,277 @@
+from __future__ import annotations
+
+from typing import (
+    TYPE_CHECKING,
+)
+
+import geff
+import numpy as np
+import zarr
+from finn_builtins.io._read import (
+    magic_imread,
+)
+from geff.affine import Affine
+from geff.validators.segmentation_validators import (
+    axes_match_seg_dims,
+    has_seg_ids_at_coords,
+    has_valid_seg_id,
+)
+from geff.validators.validators import validate_lineages, validate_tracklets
+from numpy.typing import ArrayLike
+
+from funtracks.data_model.graph_attributes import NodeAttr
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+import dask.array as da
+
+from funtracks.data_model.solution_tracks import SolutionTracks
+
+
+def relabel_seg_id_to_node_id(
+    times: ArrayLike, ids: ArrayLike, seg_ids: ArrayLike, segmentation: da.Array
+) -> np.ndarray:
+    """Relabel the segmentation from seg_id to unique node id.
+    Args:
+        times (ArrayLike): array of time points, one per node
+        ids (ArrayLike): array of node ids
+        seg_ids (ArrayLike): array of segmentation ids, one per node
+        segmentation (da.array): A dask array where segmentation label values match the
+          "seg_id" values.
+
+    Returns:
+        np.ndarray: A numpy array of dtype uint64, similar to the input segmentation
+            where each segmentation now has a unique label across time that corresponds
+            to the ID of each node.
+    """
+
+    new_segmentation = np.zeros(segmentation.shape, dtype=np.uint64)
+    for i, node in enumerate(ids):
+        mask = segmentation[times[i]].compute() == seg_ids[i]
+        new_segmentation[times[i], mask] = node
+
+    return new_segmentation
+
+
+def import_from_geff(
+    directory: Path,
+    name_map: dict[str, str],
+    segmentation: Path | None = None,
+    scale: list[float] | None = None,
+    extra_features: dict[str, bool] | None = None,
+):
+    """Load Tracks from a geff directory. Takes a name_map to map graph attributes
+    (spatial dimensions and optional track and lineage ids) to tracks attributes.
+    Optionally takes a path to segmentation data, and verifies if the segmentation data
+    matches with the graph data. If a scaling tuple is provided, it will be used to scale
+    the spatial coordinates on the graph (world coordinates) to pixel coordinates when
+    checking if segmentation data matches the graph data. If no scale is provided, the
+    geff metadata will be queried for a scale, if it is not present, no scaling will be
+    applied. Optional extra features, present as node properties in the geff, can be
+    included by providing a dictionary with keys as the feature names and values as
+    booleans indicating whether to they should be recomputed (currently only supported for
+    the 'area' feature), or loaded as static node attributes.
+
+    Args:
+        directory (Path): path to the geff tracks data or its parent folder.
+        name_map (dict[str,str]): dictionary mapping required fields to node properties.
+            Should include:
+                time,
+                (z),
+                y,
+                x,
+                (seg_id), if a segmentation is provided
+                (tracklet_id), optional, if it is a solution
+                (lineage_id), optional, if it is a solution
+        segmentation (Path | None = None): (Relative) path to segmentation data.
+        scale (list[float]): scaling information (pixel to world coordinates).
+        extra_features (dict[str: bool] | None=None): optional features to include in the
+            Tracks object. The keys are the feature names, and the boolean value indicates
+            whether to recompute the feature (area) or load it as a static node attribute.
+
+    Returns:
+        Tracks based on the geff graph and segmentation, if provided.
+    """
+
+    group = zarr.open_group(directory, mode="r")
+    metadata = dict(group.attrs)
+    selected_attrs = []
+
+    # Check that the spatiotemporal key mapping does not contain None or duplicate values.
+    # It is allowed to not include z, but it is not allowed to include z with a None or
+    # duplicate value.
+    spatio_temporal_keys = [NodeAttr.TIME.value, "z", "y", "x"]
+    spatio_temporal_map = {
+        key: name_map[key] for key in spatio_temporal_keys if key in name_map
+    }
+    if any(v is None for v in spatio_temporal_map.values()):
+        raise ValueError(
+            "The name_map cannot contain None values. Please provide a valid mapping "
+            "for all required fields."
+        )
+    if len(set(spatio_temporal_map.values())) != len(spatio_temporal_map.values()):
+        raise ValueError(
+            "The name_map cannot contain duplicate values. Please provide a unique "
+            "mapping for each required field."
+        )
+
+    # Extract the time and position attributes from the name_map, containing and optional
+    # z coordinate.
+    time_attr = name_map[NodeAttr.TIME.value]
+    selected_attrs.append(name_map[NodeAttr.TIME.value])
+    position_attr = [name_map[k] for k in ("z", "y", "x") if k in name_map]
+    selected_attrs.extend(position_attr)
+    ndims = len(position_attr) + 1
+
+    # if no scale is provided, load from metadata, if available.
+    if scale is None:
+        affine = metadata.get("affine", {}).get("matrix", None)
+        if affine is not None:
+            affine = Affine(matrix=affine)
+            linear = affine.linear_matrix
+            scale = list(np.diag(linear))
+        else:
+            scale = list([1.0] * ndims)
+
+    # Check if a track_id was provided, and if it is valid add it to list of selected
+    # attributes. If it is not provided, it will be computed again.
+    if name_map.get(NodeAttr.TRACK_ID.value) is not None:
+        # if track id is present, it is a solution graph
+        valid_track_ids, errors = validate_tracklets(
+            node_ids=group["nodes"]["ids"][:],
+            edge_ids=group["edges"]["ids"][:],
+            tracklet_ids=group["nodes"]["props"][name_map[NodeAttr.TRACK_ID.value]][
+                "values"
+            ][:],
+        )
+        if valid_track_ids:
+            selected_attrs.append(NodeAttr.TRACK_ID.value)
+
+    # Check if a lineage_id was provided, and if it is valid add it to list of selected
+    # attributes. If it is not provided, it will be a static feature (for now).
+    if name_map.get("lineage_id") is not None:
+        valid_lineages, errors = validate_lineages(
+            node_ids=group["nodes"]["ids"],
+            edge_ids=group["edges"]["ids"],
+            lineage_ids=group["nodes"]["props"][name_map["lineage_id"]]["values"],
+        )
+        if valid_lineages:
+            selected_attrs.append(name_map["lineage_id"])
+
+    # Try to load the segmentation data, if it was provided.
+    if segmentation is not None:
+        segmentation = magic_imread(
+            segmentation, use_dask=True
+        )  # change to in memory later
+
+        # check if the axes information in the metadata matches the segmentation
+        # dimensions
+        axes_match, errors = axes_match_seg_dims(directory, segmentation)
+        if not axes_match:
+            error_msg = "Axes in the geff do not match segmentation:\n" + "\n".join(
+                f"- {e}" for e in errors
+            )
+            raise ValueError(error_msg)
+
+        # Check if valid seg_ids are provided
+        if name_map.get(NodeAttr.SEG_ID.value) is not None:
+            seg_ids_valid, errors = has_valid_seg_id(
+                directory, name_map[NodeAttr.SEG_ID.value]
+            )
+            if not seg_ids_valid:
+                error_msg = "Error in validating the segmentation ids:\n" + "\n".join(
+                    f"- {e}" for e in errors
+                )
+                raise ValueError(error_msg)
+            seg_id = group["nodes"]["props"][name_map[NodeAttr.SEG_ID.value]]["values"][
+                -1
+            ]
+        else:
+            # assign the node id as seg_id instead and check in the next step if this is
+            #  valid.
+            seg_id = group["nodes"]["ids"][-1]
+
+        # Get the coordinates for the last node.
+        t = group["nodes"]["props"][name_map[NodeAttr.TIME.value]]["values"][-1]
+        z = (
+            group["nodes"]["props"][name_map["z"]]["values"][-1]
+            if len(position_attr) == 3
+            else None
+        )
+        y = group["nodes"]["props"][name_map["y"]]["values"][-1]
+        x = group["nodes"]["props"][name_map["x"]]["values"][-1]
+
+        coord = []
+        coord.append(t)
+        if z is not None:
+            coord.append(z)
+        coord.append(y)
+        coord.append(x)
+
+        # Check if the segmentation pixel value at the coordinates of the last node
+        # matches the seg id. Since the scale factor was used to convert from pixels to
+        # world coordinates, we need to invert this scale factor to get the pixel
+        # coordinates.
+        seg_id_at_coord, errors = has_seg_ids_at_coords(
+            segmentation, [coord], [seg_id], tuple(1 / s for s in scale)
+        )
+        if not seg_id_at_coord:
+            error_msg = "Error testing seg id:\n" + "\n".join(f"- {e}" for e in errors)
+            raise ValueError(error_msg)
+
+        # If the provided segmentation has seg ids that are not identical to node ids,
+        # relabel it now.
+        if group["nodes"]["ids"][-1] != seg_id:
+            times = group["nodes"]["props"][name_map[NodeAttr.TIME.value]]["values"]
+            ids = group["nodes"]["ids"]
+            seg_ids = group["nodes"]["props"][name_map[NodeAttr.SEG_ID.value]]["values"]
+
+            if not len(times) == len(ids) == len(seg_ids):
+                raise ValueError(
+                    "Encountered missing values in the seg_id to node id conversion."
+                )
+            segmentation = relabel_seg_id_to_node_id(times, ids, seg_ids, segmentation)
+
+    # All pre-checks have passed, load the graph now.
+    graph, _ = geff.read_nx(directory)
+
+    # Relabel track_id attr to NodeAttr.TRACK_ID.value.
+    if name_map.get(NodeAttr.TRACK_ID.value) is not None:
+        for _, data in graph.nodes(data=True):
+            data[NodeAttr.TRACK_ID.value] = data.pop(name_map[NodeAttr.TRACK_ID.value])
+
+    # Add optional extra features.
+    if extra_features is None:
+        extra_features = {}
+    selected_attrs.extend(extra_features.keys())
+
+    # Drop all node attributes not in selected_attrs.
+    for node in graph.nodes:
+        attrs = graph.nodes[node]
+        for key in list(attrs.keys()):
+            if key not in selected_attrs:
+                del attrs[key]
+
+    # Put segmentation data in memory now.
+    if segmentation is not None and isinstance(segmentation, da.Array):
+        segmentation = segmentation.compute()
+
+    # Create the tracks.
+    tracks = SolutionTracks(
+        graph=graph,
+        segmentation=segmentation,
+        pos_attr=position_attr,
+        time_attr=time_attr,
+        ndim=ndims,
+        scale=scale,
+    )
+    # compute the 'area' attribute if needed
+    if tracks.segmentation is not None and extra_features.get("area"):
+        nodes = tracks.graph.nodes
+        times = tracks.get_times(nodes)
+        computed_attrs = tracks._compute_node_attrs(nodes, times)
+        areas = computed_attrs[NodeAttr.AREA.value]
+        tracks._set_nodes_attr(nodes, NodeAttr.AREA.value, areas)
+
+    return tracks

--- a/src/funtracks/import_export/magic_imread.py
+++ b/src/funtracks/import_export/magic_imread.py
@@ -25,27 +25,15 @@ def read_zarr_dataset(path: Path) -> tuple[ArrayLike | list[ArrayLike], tuple[in
     if (path / ".zarray").exists():
         image = da.from_zarr(path)
         shape = image.shape
-    elif (path / ".zgroup").exists():
-        image = [
-            read_zarr_dataset(subpath)[0]
-            for subpath in sorted(path.iterdir())
-            if not subpath.name.startswith(".") and subpath.is_dir()
-        ]
-        if not image:
-            raise ValueError(f"No arrays found in zarr group: {path}")
-        shape = image[0].shape
     elif (path / "zarr.json").exists():
         data = zarr.open(store=path)
         if isinstance(data, zarr.Array):
             image = da.from_zarr(data)
             shape = image.shape
         else:
-            image = [data[k] for k in sorted(data)]
-            if not image:
-                raise ValueError(f"No arrays found in zarr group: {path}")
-            shape = image[0].shape
+            raise ValueError(f"Not a valid zarr dataset: {path}")
     else:
-        raise ValueError(f"Not a valid zarr dataset or group: {path}")
+        raise ValueError(f"Not a valid zarr dataset: {path}")
     return image, shape
 
 

--- a/src/funtracks/import_export/magic_imread.py
+++ b/src/funtracks/import_export/magic_imread.py
@@ -1,0 +1,136 @@
+"""Adapted implementation of napari.napari_builtins.io._read.magic_imread"""
+
+import re
+from glob import glob
+from pathlib import Path
+
+import dask.array as da
+import numpy as np
+import tifffile
+import zarr
+from dask import delayed
+from numpy.typing import ArrayLike
+
+
+def _alphanumeric_key(s: str):
+    return [int(c) if c.isdigit() else c for c in re.split("([0-9]+)", s)]
+
+
+def _guess_zarr_path(path: Path) -> bool:
+    return any(part.endswith(".zarr") for part in path.parts)
+
+
+def read_zarr_dataset(path: Path) -> tuple[ArrayLike | list[ArrayLike], tuple[int]]:
+    """Read a zarr dataset, including an array or a group of arrays."""
+    if (path / ".zarray").exists():
+        image = da.from_zarr(path)
+        shape = image.shape
+    elif (path / ".zgroup").exists():
+        image = [
+            read_zarr_dataset(subpath)[0]
+            for subpath in sorted(path.iterdir())
+            if not subpath.name.startswith(".") and subpath.is_dir()
+        ]
+        if not image:
+            raise ValueError(f"No arrays found in zarr group: {path}")
+        shape = image[0].shape
+    elif (path / "zarr.json").exists():
+        data = zarr.open(store=path)
+        if isinstance(data, zarr.Array):
+            image = da.from_zarr(data)
+            shape = image.shape
+        else:
+            image = [data[k] for k in sorted(data)]
+            if not image:
+                raise ValueError(f"No arrays found in zarr group: {path}")
+            shape = image[0].shape
+    else:
+        raise ValueError(f"Not a valid zarr dataset or group: {path}")
+    return image, shape
+
+
+def imread(filename: str) -> np.ndarray:
+    """Read an image from a string file path using tifffile.imwrite."""
+    return tifffile.imread(filename)
+
+
+PathOrStr = str | Path
+
+
+def magic_imread(
+    filenames: PathOrStr | list[PathOrStr], *, use_dask=None, stack=True
+) -> ArrayLike | list[ArrayLike]:
+    """Dispatch the appropriate reader given some files."""
+
+    _filenames: list[str] = (
+        [str(x) for x in filenames]
+        if isinstance(filenames, list | tuple)
+        else [str(filenames)]
+    )
+
+    if not _filenames:
+        raise ValueError("No files provided")
+
+    filenames_expanded: list[str] = []
+    for filename in _filenames:
+        path = Path(filename)
+        if path.is_dir() and not _guess_zarr_path(path):
+            dir_contents = sorted(
+                glob(str(path / "*.tif")) + glob(str(path / "*.tiff")),
+                key=_alphanumeric_key,
+            )
+            dir_contents_files = [f for f in dir_contents if not Path(f).is_dir()]
+            filenames_expanded.extend(dir_contents_files)
+        else:
+            filenames_expanded.append(filename)
+
+    if not filenames_expanded:
+        raise ValueError(f"No readable TIFF files found in {filenames}")
+
+    if use_dask is None:
+        use_dask = len(filenames_expanded) > 1
+
+    images: list[ArrayLike] = []
+    shape: tuple[int, ...] | None = None
+    dtype = None
+
+    for filename in filenames_expanded:
+        path = Path(filename)
+        if _guess_zarr_path(path):
+            image, zarr_shape = read_zarr_dataset(path)
+            if len(zarr_shape) == 1:
+                continue
+            if shape is None:
+                shape = zarr_shape
+        else:
+            if shape is None:
+                image = imread(filename)
+                shape = image.shape
+                dtype = image.dtype
+            if use_dask:
+                image = da.from_delayed(
+                    delayed(imread)(filename), shape=shape, dtype=dtype
+                )
+            elif len(images) > 0:
+                image = imread(filename)
+        images.append(image)
+
+    if not images:
+        raise ValueError("No valid images loaded")
+
+    if len(images) == 1:
+        return images[0]
+    elif stack:
+        if use_dask:
+            return da.stack(images)
+        else:
+            try:
+                return np.stack(images)
+            except ValueError as e:
+                raise ValueError(
+                    "To stack multiple files with numpy, all input arrays must have the"
+                    " same shape. Set `use_dask=True` to allow stacking with different "
+                    "shapes."
+                ) from e
+    else:
+        return images

--- a/tests/import_export/test_import_from_geff.py
+++ b/tests/import_export/test_import_from_geff.py
@@ -1,0 +1,178 @@
+import numpy as np
+import pytest
+import tifffile
+from geff.testing.data import create_memory_mock_geff
+
+from funtracks.import_export.import_from_geff import import_from_geff
+
+
+@pytest.fixture
+def valid_store_and_attrs():
+    store, graphattrs = create_memory_mock_geff(
+        node_id_dtype="int",
+        node_axis_dtypes={"position": "float64", "time": "int64"},
+        directed=True,
+        num_nodes=5,
+        num_edges=2,
+        include_t=True,
+        include_z=False,
+        include_y=True,
+        include_x=True,
+        extra_node_props={
+            "track_id": np.arange(5),
+            "seg_id": np.array([10, 20, 30, 40, 50]),
+            "lineage_id": np.arange(5),
+            "area": np.array([20, 41, 42, 776, 21]),
+            "random_feature": np.array(["a", "b", "c", "d", "e"]),
+            "random_feature2": np.array(["a", "b", "c", "d", "e"]),
+        },
+    )
+    return store, graphattrs
+
+
+@pytest.fixture
+def invalid_store_and_attrs():
+    store, graphattrs = create_memory_mock_geff(
+        node_id_dtype="int",
+        node_axis_dtypes={"position": "float64", "time": "int64"},
+        directed=True,
+        num_nodes=5,
+        num_edges=2,
+        include_t=True,
+        include_z=False,
+        include_y=True,
+        include_x=True,
+        extra_node_props={
+            "track_id": np.arange(5),
+            "seg_id": np.array([10.453, 20.23, 30.56, 40.78, 50.92]),
+            "lineage_id": np.arange(5),
+            "area": np.array([20, 41, 42, 776, 21]),
+        },
+    )
+    return store, graphattrs
+
+
+@pytest.fixture
+def valid_segmentation():
+    shape = (6, 600, 200)
+    seg = np.zeros(shape, dtype=int)
+
+    times = [1, 2, 3, 4, 5]
+    x = [1.0, 0.775, 0.55, 0.325, 0.1]
+    y = [100, 200, 300, 400, 500]
+    scale = [1, 1, 100]
+    seg_ids = np.array([10, 20, 30, 40, 50])
+
+    for t, y_val, x_f, seg_id in zip(times, y, x, seg_ids, strict=False):
+        x = int(x_f * scale[2])
+        seg[t, y_val, x] = seg_id
+    return seg
+
+
+def test_duplicate_or_none_in_name_map(valid_store_and_attrs):
+    """Test that duplicate values or missing t/y/x attributes are caught"""
+
+    store, _ = valid_store_and_attrs
+    # Duplicate value
+    name_map = {"time": "time", "y": "y", "x": "y"}
+    with pytest.raises(ValueError, match="duplicate values"):
+        import_from_geff(store, name_map)
+    # None value
+    name_map = {"time": None, "y": "y", "x": "x"}
+    with pytest.raises(ValueError, match="None values"):
+        import_from_geff(store, name_map)
+
+
+def test_segmentation_axes_mismatch(valid_store_and_attrs, tmp_path):
+    """Test checking if number of dimensions match and if coordinates are within
+    bounds."""
+
+    store, _ = valid_store_and_attrs
+    name_map = {"time": "t", "y": "y", "x": "x", "seg_id": "seg_id"}
+
+    # Provide a segmentation with wrong shape
+    wrong_seg = np.zeros((2, 20, 200), dtype=np.uint16)
+    seg_path = tmp_path / "wrong_seg.npy"
+    np.save(seg_path, wrong_seg)
+    with pytest.raises(ValueError, match="out of bounds"):
+        import_from_geff(store, name_map, segmentation=seg_path)
+
+    # Provide a segmentation with a different number of dimensions than the graph.
+    wrong_seg = np.zeros((2, 20, 200, 200), dtype=np.uint16)
+    seg_path = tmp_path / "wrong_seg2.npy"
+    np.save(seg_path, wrong_seg)
+    with pytest.raises(ValueError, match="Axes in the geff do not match"):
+        import_from_geff(store, name_map, segmentation=seg_path)
+
+
+def test_tracks_with_segmentation(
+    valid_store_and_attrs, invalid_store_and_attrs, valid_segmentation, tmp_path
+):
+    """Test relabeling of the segmentation from seg_id to node_id."""
+
+    store, _ = valid_store_and_attrs
+    name_map = {"time": "t", "y": "y", "x": "x", "seg_id": "seg_id"}
+    valid_segmentation_path = tmp_path / "segmentation.tif"
+    tifffile.imwrite(valid_segmentation_path, valid_segmentation)
+
+    # Test that a tracks object is produced and that the seg_id has been relabeled.
+    scale = [1, 1, (1 / 100)]
+    extra_features = {"area": True, "random_feature": False}
+    tracks = import_from_geff(
+        store,
+        name_map,
+        segmentation=valid_segmentation_path,
+        scale=scale,
+        extra_features=extra_features,
+    )
+    assert hasattr(tracks, "segmentation")
+    assert tracks.segmentation.shape == valid_segmentation.shape
+    last_node = list(tracks.graph.nodes)[-1]
+    coords = [
+        tracks.graph.nodes[last_node]["t"],
+        tracks.graph.nodes[last_node]["y"],
+        tracks.graph.nodes[last_node]["x"],
+    ]
+    coords = tuple(int(c * 1 / s) for c, s in zip(coords, scale, strict=True))
+    assert (
+        valid_segmentation[tuple(coords)] == 50
+    )  # in original segmentation, the pixel value is equal to seg_id
+    assert (
+        tracks.segmentation[tuple(coords)] == last_node
+    )  # test that the seg id has been relabeled
+
+    # Check that only required/requested features are present, and that area is recomputed
+    _, data = list(tracks.graph.nodes(data=True))[-1]
+    assert "random_feature" in data
+    assert "random_feature2" not in data
+    assert "area" in data
+    assert (
+        data["area"] == 0.01
+    )  # recomputed area values should be 1 pixel, so 0.01 after applying the scaling.
+
+    # Check that area is not recomputed but taken directly from the graph
+    extra_features = {"area": False, "random_feature": False}  # set Recompute to False
+    tracks = import_from_geff(
+        store,
+        name_map,
+        segmentation=valid_segmentation_path,
+        scale=scale,
+        extra_features=extra_features,
+    )
+    _, data = list(tracks.graph.nodes(data=True))[-1]
+    assert "area" in data
+    assert data["area"] == 21
+
+    # Test that import fails with ValueError when scaling information is missing or
+    # incorrect
+    with pytest.raises(ValueError):
+        tracks = import_from_geff(
+            store, name_map, segmentation=valid_segmentation_path, scale=None
+        )
+
+    # Test that import fails with ValueError when invalid seg_ids are provided.
+    store, _ = invalid_store_and_attrs
+    with pytest.raises(ValueError):
+        tracks = import_from_geff(
+            store, name_map, segmentation=valid_segmentation_path, scale=scale
+        )


### PR DESCRIPTION
Add an import_from_geff function to convert a geff directory to a SolutionTracks object. 

Inputs: 
  - a directory to a geff folder
  - a dictionary mapping node properties to time, position, seg_id (if seg provided), track_id (optional), lineage_id (optional). 
  - path to the segmentation (zarr folder, directory of tiffs, single tiff hyperstack file).
  - optional extra (static) features to include, and whether to recompute them (only supported for 'area' at the moment). 
  - scaling factors (pixel to world coordinate)

Outputs:
 - SolutionTracks
  
Several checks are performed to make sure the provided information is correct (property mapping, scaling, track_id validity, match between segmentation and graph data).

Notes/To do
The geff could technically provide valid track_ids, but the SolutionTracks class still recomputes the track_ids, should we make this optional? 
Checks are failing because of the use of the magic_imread (finn_builtins) function, should we implement a similar function ourselves, or can we rely on napari/finn for this function?

