### PR TITLE
Use InMemoryGeff when importing tracks from geff

### DIFF
--- a/src/funtracks/data_model/solution_tracks.py
+++ b/src/funtracks/data_model/solution_tracks.py
@@ -37,14 +37,10 @@ class SolutionTracks(Tracks):
             ndim=ndim,
         )
         self.max_track_id: int
+        self.track_id_to_node: dict[int, list[int]] = {}
 
         # recompute track_id if requested or missing
-        if graph.number_of_nodes() == 0:
-            has_track_id = False
-        else:
-            has_track_id = NodeAttr.TRACK_ID.value in graph.nodes[next(iter(graph.nodes))]
-        if recompute_track_ids or not has_track_id:
-            self._initialize_track_ids()
+        self._initialize_track_ids(recompute_track_ids)
 
     @classmethod
     def from_tracks(cls, tracks: Tracks):
@@ -55,6 +51,7 @@ class SolutionTracks(Tracks):
             pos_attr=tracks.pos_attr,
             scale=tracks.scale,
             ndim=tracks.ndim,
+            recompute_track_ids=False,
         )
 
     @property
@@ -84,15 +81,15 @@ class SolutionTracks(Tracks):
             self.track_id_to_node[value] = []
         self.track_id_to_node[value].append(node)
 
-    def _initialize_track_ids(self):
+    def _initialize_track_ids(self, recompute: bool = False):
         self.max_track_id = 0
-        self.track_id_to_node = {}
 
         if self.graph.number_of_nodes() != 0:
-            if len(self.node_id_to_track_id) < self.graph.number_of_nodes():
+            if len(self.node_id_to_track_id) < self.graph.number_of_nodes() or recompute:
                 # not all nodes have a track id: reassign
                 self._assign_tracklet_ids()
             else:
+                # only populate track_id_to_node and set max_track_id
                 self.max_track_id = max(self.node_id_to_track_id.values())
                 for node, track_id in self.node_id_to_track_id.items():
                     if track_id not in self.track_id_to_node:

--- a/src/funtracks/import_export/export_to_geff.py
+++ b/src/funtracks/import_export/export_to_geff.py
@@ -8,8 +8,8 @@ import geff
 import networkx as nx
 import numpy as np
 import zarr
-from geff.affine import Affine
-from geff.metadata_schema import GeffMetadata
+from geff.metadata import GeffMetadata
+from geff.metadata._affine import Affine
 
 from funtracks.data_model.graph_attributes import NodeAttr
 

--- a/src/funtracks/import_export/import_from_geff.py
+++ b/src/funtracks/import_export/import_from_geff.py
@@ -209,13 +209,16 @@ def import_from_geff(
 
     # if no scale is provided, load from metadata, if available.
     if scale is None:
-        affine = metadata.get("affine", {}).get("matrix", None)
+        scale = list([1.0] * ndims)
+
+        # overwrite if valid affine is provided
+        affine = metadata.get("affine", {})
         if affine is not None:
-            affine = Affine(matrix=affine)
-            linear = affine.linear_matrix
-            scale = list(np.diag(linear))
-        else:
-            scale = list([1.0] * ndims)
+            matrix = affine.get("matrix", None)
+            if matrix is not None:
+                affine = Affine(matrix=matrix)
+                linear = affine.linear_matrix
+                scale = list(np.diag(linear))
 
     # Check if a track_id was provided, and if it is valid add it to list of selected
     # attributes. If it is not provided, it will be computed again.

--- a/tests/data_model/test_solution_tracks.py
+++ b/tests/data_model/test_solution_tracks.py
@@ -5,8 +5,13 @@ from funtracks.data_model import NodeAttr, SolutionTracks, Tracks
 from funtracks.data_model.actions import AddNodes
 
 
+def test_recompute_track_ids(graph_2d):
+    tracks = SolutionTracks(graph_2d, ndim=3, recompute_track_ids=True)
+    assert tracks.get_next_track_id() == 5
+
+
 def test_next_track_id(graph_2d):
-    tracks = SolutionTracks(graph_2d, ndim=3)
+    tracks = SolutionTracks(graph_2d, ndim=3, recompute_track_ids=False)
     assert tracks.get_next_track_id() == 6
     AddNodes(
         tracks,
@@ -28,9 +33,10 @@ def test_from_tracks_cls(graph_2d):
     assert solution_tracks.scale == tracks.scale
     assert solution_tracks.ndim == tracks.ndim
     assert solution_tracks.get_node_attr(6, NodeAttr.TRACK_ID.value) == 5
-    # delete track id on one node to trigger reassignment of track_ids.
+    # delete track id on one node triggers reassignment of track_ids even when recompute
+    # is False.
     solution_tracks.graph.nodes[1].pop(NodeAttr.TRACK_ID.value, None)
-    solution_tracks._initialize_track_ids()
+    solution_tracks._initialize_track_ids(recompute=False)
     # should have reassigned new track_id to node 6
     assert solution_tracks.get_node_attr(6, NodeAttr.TRACK_ID.value) == 4
     assert solution_tracks.get_node_attr(1, NodeAttr.TRACK_ID.value) == 1  # still 1


### PR DESCRIPTION
This is to ensure compatibility with updated geff segmentation validation functions that use an InMemoryGeff as input. I think we can read the geff once as InMemoryGeff instead of multiple times as a zarr group, and use that one for all our checks? 