### PR TITLE
enable lineage id feature by default

### DIFF
--- a/src/funtracks/data_model/solution_tracks.py
+++ b/src/funtracks/data_model/solution_tracks.py
@@ -28,6 +28,7 @@ class SolutionTracks(Tracks):
         time_attr: str | None = None,
         pos_attr: str | tuple[str] | list[str] | None = None,
         tracklet_attr: str | None = None,
+        lineage_attr: str | None = None,
         scale: list[float] | None = None,
         ndim: int | None = None,
         features: FeatureDict | None = None,
@@ -51,6 +52,8 @@ class SolutionTracks(Tracks):
                 Defaults to "pos" if None.
             tracklet_attr (str | None): Graph attribute name for tracklet/track IDs.
                 Defaults to "track_id" if None.
+            lineage_attr (str | None): Graph attribute name for lineage IDs.
+                Defaults to "lineage_id" if None.
             scale (list[float] | None): Scaling factors for each dimension (including
                 time). If None, all dimensions scaled by 1.0.
             ndim (int | None): Number of dimensions (3 for 2D+time, 4 for 3D+time).
@@ -67,6 +70,7 @@ class SolutionTracks(Tracks):
             time_attr=time_attr,
             pos_attr=pos_attr,
             tracklet_attr=tracklet_attr,
+            lineage_attr=lineage_attr,
             scale=scale,
             ndim=ndim,
             features=features,
@@ -110,16 +114,13 @@ class SolutionTracks(Tracks):
     @classmethod
     def from_tracks(cls, tracks: Tracks):
         force_recompute = False
-        if tracks.features.lineage_key is None:
-            tracks.features.lineage_key = "lineage_id"
-            force_recompute = True
-        elif (tracklet_key := tracks.features.tracklet_key) is not None:
+        if (tracklet_key := tracks.features.tracklet_key) is not None:
             # Check if all nodes have track_id before trusting existing track IDs
             # Short circuit on first missing track_id
             for node in tracks.graph.nodes():
                 if (
                     tracks.get_node_attr(node, tracklet_key) is None
-                    or tracks.get_node_attr(node, tracks.features.lineage_key) is None
+                    or tracks.get_node_attr(node, tracks.features.lineage_key) is None  # type: ignore[arg-type]
                 ):
                     force_recompute = True
                     break

--- a/tests/annotators/test_track_annotator.py
+++ b/tests/annotators/test_track_annotator.py
@@ -19,14 +19,14 @@ class TestTrackAnnotator:
         # Features start disabled by default
         assert len(ann.all_features) == 2
         assert len(ann.features) == 0
-        assert len(ann.lineage_id_to_nodes) == 0
+        assert len(ann.lineage_id_to_nodes) == 2
 
         ann = TrackAnnotator(tracks, tracklet_key="track_id")
         assert len(ann.all_features) == 2
         assert len(ann.features) == 0
-        assert len(ann.lineage_id_to_nodes) == 0
+        assert len(ann.lineage_id_to_nodes) == 2
         assert len(ann.tracklet_id_to_nodes) == 4
-        assert ann.max_lineage_id == 0
+        assert ann.max_lineage_id == 2
         assert ann.max_tracklet_id == 5
 
     def test_compute_all(self, get_tracks, ndim, with_seg) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -107,6 +107,9 @@ def _make_graph(
     # Track IDs
     track_ids = {1: 1, 2: 2, 3: 3, 4: 3, 5: 3, 6: 5}
 
+    # Lineage IDs
+    lineage_ids = {1: 1, 2: 1, 3: 1, 4: 1, 5: 1, 6: 2}
+
     # Build nodes with requested features
     nodes = []
     for node_id, attrs in base_nodes:
@@ -115,6 +118,7 @@ def _make_graph(
             node_attrs["pos"] = positions[node_id]
         if with_track_id:
             node_attrs["track_id"] = track_ids[node_id]
+            node_attrs["lineage_id"] = lineage_ids[node_id]
         if with_area:
             node_attrs["area"] = areas[node_id]
         nodes.append((node_id, node_attrs))
@@ -196,7 +200,15 @@ def get_tracks(get_graph, get_segmentation) -> Callable[..., "Tracks | SolutionT
         exist in the test graph fixtures.
     """
     from funtracks.data_model import SolutionTracks, Tracks
-    from funtracks.features import Area, FeatureDict, IoU, Position, Time, TrackletID
+    from funtracks.features import (
+        Area,
+        FeatureDict,
+        IoU,
+        LineageID,
+        Position,
+        Time,
+        TrackletID,
+    )
 
     def _make_tracks(
         ndim: int,
@@ -232,9 +244,11 @@ def get_tracks(get_graph, get_segmentation) -> Callable[..., "Tracks | SolutionT
             features_dict["area"] = Area(ndim=ndim)
             features_dict["iou"] = IoU()
             features_dict["track_id"] = TrackletID()
+            features_dict["lineage_id"] = LineageID()
         elif is_solution:
             # SolutionTracks without seg: has track_id but not area/iou
             features_dict["track_id"] = TrackletID()
+            features_dict["lineage_id"] = LineageID()
 
         feature_dict = FeatureDict(
             features=features_dict,
@@ -275,6 +289,7 @@ def graph_2d_list() -> nx.DiGraph:
                 "t": 0,
                 "area": 1245,
                 "track_id": 1,
+                "lineage_id": 1,
             },
         ),
         (
@@ -285,6 +300,7 @@ def graph_2d_list() -> nx.DiGraph:
                 "t": 1,
                 "area": 500,
                 "track_id": 2,
+                "lineage_id": 2,
             },
         ),
     ]
@@ -335,7 +351,8 @@ def get_graph(request) -> Callable[..., nx.DiGraph]:
         with_features: Feature level to include:
             - "clean": time only
             - "position": time + pos
-            - "track_id": time + pos + track_id (for SolutionTracks without seg)
+            - "track_id": time + pos + track_id and lineage_id (for SolutionTracks
+                without seg)
             - "computed": time + pos + track_id + area + iou (full features)
 
     Returns:

--- a/tests/data_model/test_solution_tracks.py
+++ b/tests/data_model/test_solution_tracks.py
@@ -37,7 +37,7 @@ def test_node_id_to_track_id(graph_2d_with_computed_features):
         tracks.node_id_to_track_id  # noqa B018
 
 
-def test_from_tracks_cls_without_lineage_ids(graph_2d_with_computed_features):
+def test_from_tracks_cls(graph_2d_with_computed_features):
     tracks = Tracks(
         graph_2d_with_computed_features,
         ndim=3,
@@ -46,10 +46,6 @@ def test_from_tracks_cls_without_lineage_ids(graph_2d_with_computed_features):
         tracklet_attr=track_attrs["tracklet_attr"],
         scale=(2, 2, 2),
     )
-
-    # Even though the track_ids are present, since lineage_id is missing, track and
-    # lineage ids will still be recomputed.
-    tracks.features.lineage_key = "lineage_id"
     solution_tracks = SolutionTracks.from_tracks(tracks)
     assert solution_tracks.graph == tracks.graph
     assert solution_tracks.segmentation == tracks.segmentation
@@ -57,40 +53,7 @@ def test_from_tracks_cls_without_lineage_ids(graph_2d_with_computed_features):
     assert solution_tracks.features.position_key == tracks.features.position_key
     assert solution_tracks.scale == tracks.scale
     assert solution_tracks.ndim == tracks.ndim
-    assert (
-        solution_tracks.get_node_attr(6, tracks.features.tracklet_key) == 4
-    )  # new value
-    # after recompute
-
-
-def test_from_tracks_cls_with_lineage_ids(graph_2d_with_computed_features):
-    # In case we do have both lineage ids and track ids provided on all nodes,
-    # we assume they have been tested and if all nodes have a value, no recomputing is
-    # necessary.
-
-    # simulate these tracks to also have lineage ids
-    tracks = Tracks(
-        graph_2d_with_computed_features,
-        ndim=3,
-        pos_attr="POSITION",
-        time_attr="TIME",
-        tracklet_attr=track_attrs["tracklet_attr"],
-        scale=(2, 2, 2),
-    )
-    tracks.features.lineage_key = "lineage_id"
-    tracks._set_nodes_attr(
-        nodes=[1, 2, 3, 4, 5, 6], attr="lineage_id", values=[1, 1, 1, 1, 1, 2]
-    )
-    solution_tracks = SolutionTracks.from_tracks(tracks)
-
-    assert solution_tracks.graph == tracks.graph
-    assert solution_tracks.segmentation == tracks.segmentation
-    assert solution_tracks.features.time_key == tracks.features.time_key
-    assert solution_tracks.features.position_key == tracks.features.position_key
-    assert solution_tracks.scale == tracks.scale
-    assert solution_tracks.ndim == tracks.ndim
-    assert solution_tracks.get_node_attr(6, tracks.features.tracklet_key) == 5  # original
-    # value
+    assert solution_tracks.get_node_attr(6, tracks.features.tracklet_key) == 5
 
 
 def test_from_tracks_cls_recompute(graph_2d_with_computed_features):


### PR DESCRIPTION
Should fix the bug observed in motile-tracker: https://github.com/funkelab/motile_tracker/issues/314, when creating a tracking result with motile. 
I will double check tomorrow if this is also true for all imported tracks, especially since force_recompute may be false