### PR TITLE
Fix CSV headers when value_names are missing

### DIFF
--- a/src/funtracks/import_export/csv/_export.py
+++ b/src/funtracks/import_export/csv/_export.py
@@ -78,7 +78,12 @@ def export_to_csv(
                 else:
                     # Fall back to display_name or feature_name with index suffix
                     base_name = feature_dict.get("display_name", feature_name)
-                    header.extend([f"{base_name}_{i}" for i in range(num_values)])
+                    if len(base_name) == num_values:
+                        # use list elements
+                        header.extend(list(base_name))
+                    else:
+                        # use a suffix
+                        header.extend([f"{base_name}_{i}" for i in range(num_values)])
             else:
                 # Single-value feature: use display_name or feature_name
                 col_name = feature_dict.get("display_name", feature_name)


### PR DESCRIPTION
When a list feature somehow lacks the value_names (this happened with the pos feature for me, not sure why), the fallback is to use the display_name + suffix. However, if the display_name is a list already, the header is extended multiple times, because of the comma separation. This update is to check if display_name is a list already, and if so, use those elements. If it is not, the suffix approach is used. Should fix issue #157. 