### PR TITLE
289 circular graph error

### DIFF
--- a/src/funtracks/candidate_graph/compute_graph.py
+++ b/src/funtracks/candidate_graph/compute_graph.py
@@ -36,18 +36,6 @@ def compute_graph_from_seg(
     """
     # add nodes
     cand_graph, node_frame_dict = nodes_from_segmentation(segmentation, scale=scale)
-    # safety check for duplicate nodes with early exit for efficiency
-    seen = set()
-    for values in node_frame_dict.values():
-        for x in set(values):
-            if x in seen:
-                logger.info(
-                    "Duplicate values are found among nodes, segmentation will be "
-                    "relabeled"
-                )
-                raise ValueError("Duplicate values found among nodes")
-            seen.add(x)
-
     logger.info("Candidate nodes: %d", cand_graph.number_of_nodes())
 
     # add edges

--- a/src/funtracks/candidate_graph/utils.py
+++ b/src/funtracks/candidate_graph/utils.py
@@ -65,6 +65,8 @@ def nodes_from_segmentation(
             attrs[NodeAttr.SEG_ID.value] = regionprop.label
             centroid = regionprop.centroid  # [z,] y, x
             attrs[NodeAttr.POS.value] = centroid
+            if node_id in cand_graph.nodes:
+                raise ValueError("Duplicate values found among nodes")
             cand_graph.add_node(node_id, **attrs)
             nodes_in_frame.append(node_id)
         if nodes_in_frame:


### PR DESCRIPTION
Add an extra check for duplicate nodes when creating the candidate graph from segmentation. Raise a ValueError if duplicates are found, which should be caught by MotileTracker, and request updating the MotileRun with relabeled segmentation. 