### PR TITLE
Remove deprecated import arguments

### DIFF
--- a/src/funtracks/import_export/_tracks_builder.py
+++ b/src/funtracks/import_export/_tracks_builder.py
@@ -321,7 +321,6 @@ class TracksBuilder(ABC):
         self,
         source: Path | pd.DataFrame,
         node_name_map: dict[str, str | list[str]],
-        node_features: dict[str, bool] | None = None,
     ) -> None:
         """Load data from source file and convert to InMemoryGeff format.
 
@@ -330,7 +329,6 @@ class TracksBuilder(ABC):
         Args:
             source: Path to data source (zarr store, CSV file, etc.) or DataFrame
             node_name_map: Maps standard keys to source property names
-            node_features: Optional features dict for backward compatibility
         """
 
     def _combine_multi_value_props(
@@ -577,87 +575,70 @@ class TracksBuilder(ABC):
 
         return new_segmentation, scale, graph
 
+    # Structural keys that are handled by graph construction / SolutionTracks.__init__
+    # and should not be registered as features by enable_features().
+    STRUCTURAL_KEYS = frozenset({"time", "id", "parent_id", "seg_id"})
+
     def enable_features(
         self,
         tracks: SolutionTracks,
-        features: dict[str, bool] | None,
+        name_map: dict[str, str | list[str]],
         feature_type: Literal["node", "edge"] = "node",
     ) -> None:
-        """Enable and register features on tracks object.
+        """Enable and register features on tracks object from a name map.
 
-        Common logic shared across all formats for both node and edge features.
+        For each key in name_map that is not structural (time, id, parent_id,
+        seg_id) and not already registered in tracks.features:
+        - If the key matches an annotator-managed feature and data was loaded
+          for it, enable it via the annotator (recompute=False).
+        - Otherwise, if data was loaded for it, register it as a static feature.
 
         Args:
             tracks: SolutionTracks object to add features to
-            features: Dict mapping feature names to recompute flags
+            name_map: Mapping from standard funtracks keys to source property
+                names (same format as node_name_map / edge_name_map).
             feature_type: Type of features ("node" or "edge")
         """
-        if features is None:
+        if name_map is None:
             return
 
         if self.in_memory_geff is None:
             raise ValueError("No data loaded. Call load_source() first.")
 
-        # Get the appropriate props dict based on feature_type
         props = (
             self.in_memory_geff["node_props"]
             if feature_type == "node"
             else self.in_memory_geff["edge_props"]
         )
 
-        # Validate requested features before enabling
-        invalid_features = []
-        for key, recompute in features.items():
-            if recompute:
-                # Features to compute must exist in annotators
-                if key not in tracks.annotators.all_features:
-                    invalid_features.append(key)
-            else:
-                # Features to load must exist in props
-                if key not in props:
-                    invalid_features.append(key)
-
-        if invalid_features:
-            available_computed = list(tracks.annotators.all_features.keys())
-            available_geff = list(props.keys())
-            raise KeyError(
-                f"{feature_type.capitalize()} features not available: "
-                f"{invalid_features}. "
-                f"Available computed features: {available_computed}. "
-                f"Available {feature_type} properties: {available_geff}"
-            )
-
-        # Separate into features that exist in annotators vs static features
-        annotator_features = {
-            key: recompute
-            for key, recompute in features.items()
-            if key in tracks.annotators.all_features
-        }
-
-        # Enable annotator features with appropriate recompute flag
-        for key, recompute in annotator_features.items():
-            tracks.enable_features([key], recompute=recompute)
-
-        # Register static features (features not in annotator registry)
-        static_keys = [key for key in features if key not in annotator_features]
         static_features: dict[str, Feature] = {}
-        for key in static_keys:
-            static_features[key] = Feature(
-                display_name=key,
-                feature_type=feature_type,
-                value_type=infer_dtype_from_array(props[key]["values"]),
-                num_values=1,
-                default_value=None,
-            )
-        tracks.features.update(static_features)
+        for key in name_map:
+            if key in self.STRUCTURAL_KEYS:
+                continue
+            if key in tracks.features:
+                continue
+            if key not in props:
+                continue
+
+            if key in tracks.annotators.all_features:
+                tracks.enable_features([key], recompute=False)
+            else:
+                static_features[key] = Feature(
+                    display_name=key,
+                    feature_type=feature_type,
+                    value_type=infer_dtype_from_array(props[key]["values"]),
+                    num_values=1,
+                    default_value=None,
+                )
+
+        if static_features:
+            tracks.features.update(static_features)
 
     def build(
         self,
         source: Path | pd.DataFrame,
         segmentation: Path | np.ndarray | None = None,
         scale: list[float] | None = None,
-        node_features: dict[str, bool] | None = None,
-        edge_features: dict[str, bool] | None = None,
         node_name_map: dict[str, str | list[str]] | None = None,
         database: str | None = None,
     ) -> SolutionTracks:
@@ -667,8 +648,6 @@ class TracksBuilder(ABC):
             source: Path to data source or DataFrame
             segmentation: Optional path to segmentation or pre-loaded segmentation array
             scale: Optional spatial scale
-            node_features: Optional node features to enable/load
-            edge_features: Optional edge features to enable/load
             node_name_map: Optional node_name_map to override self.node_name_map
             database: Optional path to a SQLite database file for backing storage.
                 If None (default), an in-memory/temp graph is used.
@@ -718,7 +697,7 @@ class TracksBuilder(ABC):
         self.validate_name_map(has_segmentation=segmentation is not None)
 
         # 1. Load source data to InMemoryGeff
-        self.load_source(source, self.node_name_map, node_features)
+        self.load_source(source, self.node_name_map)
         if self.in_memory_geff is None:
             raise ValueError("load_source() must populate self.in_memory_geff")
 
@@ -757,10 +736,9 @@ class TracksBuilder(ABC):
             scale=scale,
         )
 
-        # 8. Enable and register features
-        if node_features is not None:
-            self.enable_features(tracks, node_features, feature_type="node")
-        if edge_features is not None:
-            self.enable_features(tracks, edge_features, feature_type="edge")
+        # 8. Enable and register features from name maps
+        self.enable_features(tracks, self.node_name_map, feature_type="node")
+        if self.edge_name_map is not None:
+            self.enable_features(tracks, self.edge_name_map, feature_type="edge")
 
         return tracks

--- a/src/funtracks/import_export/csv/_import.py
+++ b/src/funtracks/import_export/csv/_import.py
@@ -62,14 +62,12 @@ class CSVTracksBuilder(TracksBuilder):
         self,
         source: Path | pd.DataFrame,
         node_name_map: dict[str, str | list[str]],
-        node_features: dict[str, bool] | None = None,
     ) -> None:
         """Load CSV and convert to InMemoryGeff format.
 
         Args:
             source: Path to CSV file or DataFrame
             node_name_map: Maps standard keys to CSV column names
-            node_features: Optional features dict for backward compatibility
         """
         # Read CSV or use provided DataFrame
         df = (
@@ -86,19 +84,10 @@ class CSVTracksBuilder(TracksBuilder):
         if "id" in df.columns and "parent_id" in df.columns:
             df = _ensure_integer_ids(df)
 
-        # For backward compatibility, extend node_name_map with node_features
-        # Only add features that should be loaded (recompute=False)
-        extended_name_map = dict(node_name_map)
-        if node_features is not None:
-            for feature_key, recompute in node_features.items():
-                if feature_key not in extended_name_map and not recompute:
-                    # Assume feature name in CSV matches standard key
-                    extended_name_map[feature_key] = feature_key
-
         # Build a new DataFrame with standard key names, copying data for each mapping.
         # Multi-value features keep original names (combining happens in TracksBuilder)
         new_df_data = {}
-        for target_key, source_col in flatten_name_map(extended_name_map):
+        for target_key, source_col in flatten_name_map(node_name_map):
             if source_col in df.columns and target_key not in new_df_data:
                 new_df_data[target_key] = df[source_col].copy()
         df = pd.DataFrame(new_df_data)
@@ -199,11 +188,9 @@ def tracks_from_df(
     df: pd.DataFrame,
     segmentation: np.ndarray | None = None,
     scale: list[float] | None = None,
-    features: dict[str, str] | None = None,
     node_name_map: dict[str, str | list[str]] | None = None,
-    name_map: dict[str, str | list[str]] | None = None,  # deprecated
 ) -> SolutionTracks:
-    """Import tracks from pandas DataFrame (motile_tracker-compatible API).
+    """Import tracks from pandas DataFrame.
 
     Turns a pandas DataFrame with columns:
         time, [z], y, x, id, parent_id, [seg_id], [optional custom attr 1], ...
@@ -219,20 +206,13 @@ def tracks_from_df(
             corresponds to the label ids in the segmentation array. Defaults to None.
         scale: The scale of the segmentation (including the time dimension).
             Defaults to None.
-        features: Dict mapping measurement attributes (area, volume) to value that
-            specifies a column from which to import. If value equals "Recompute",
-            recompute these values instead of importing them from a column.
-            Example: {"Area": "area"} loads from column "area"
-                     {"Area": "Recompute"} recomputes from segmentation
-            Defaults to None.
         node_name_map: Optional mapping from standard funtracks keys to DataFrame
             column names: {standard_key: column_name}.
-            For example: {"time": "t", "pos": ["y", "x"], "seg_id": "label"}
+            For example: {"time": "t", "pos": ["y", "x"], "area": "Area"}
             - Keys are standard funtracks attribute names (e.g., "time", "pos", "seg_id")
-            - Values are column names from the DataFrame (e.g., "t", "label")
+            - Values are column names from the DataFrame (e.g., "t", "Area")
             - For multi-value features like position, use a list: {"pos": ["y", "x"]}
             If None, column names are auto-inferred using fuzzy matching.
-        name_map: Deprecated. Use node_name_map instead.
 
     Returns:
         SolutionTracks: a solution tracks object
@@ -244,41 +224,6 @@ def tracks_from_df(
     Example:
         >>> tracks = tracks_from_df(df, segmentation=seg, scale=[1.0, 1.0, 0.5, 0.5])
     """
-    from warnings import warn
-
-    # Handle deprecated name_map parameter
-    if name_map is not None:
-        warn(
-            "name_map is deprecated, use node_name_map instead",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        if node_name_map is None:
-            node_name_map = name_map
-
-    # Convert features dict from motile_tracker format to funtracks format
-    node_features = None
-    if features is not None:
-        node_features = {}
-        # Convert feature keys to lowercase for consistency
-        features = {key.lower(): val for key, val in features.items()}
-        for feature_key, feature_value in features.items():
-            if feature_value == "Recompute":
-                # Recompute from segmentation
-                node_features[feature_key] = True
-            else:
-                # Use the lowercase standard key (feature_key) so that core features
-                # like "area" are stored with a consistent lowercase key in the graph,
-                # avoiding SQLite duplicate-column errors when SolutionTracks later tries
-                # to register the same feature under its canonical lowercase name.
-                node_features[feature_key] = False
-                # Ensure node_name_map maps the standard key to the actual column name.
-                # Without this, load_source would look for a column named "area" when
-                # the CSV actually has "Area".
-                if node_name_map is not None and feature_key not in node_name_map:
-                    node_name_map = dict(node_name_map)  # copy to avoid mutating caller
-                    node_name_map[feature_key] = feature_value
-
     builder = CSVTracksBuilder()
 
     if node_name_map is not None:
@@ -288,12 +233,9 @@ def tracks_from_df(
         # Auto-infer name mapping from DataFrame columns
         builder.prepare(df)
 
-    # instead of a separate segmentation array
-
     return builder.build(
         df,
         segmentation,
         scale=scale,
-        node_features=node_features,
         node_name_map=builder.node_name_map,
     )

--- a/src/funtracks/import_export/geff/_import.py
+++ b/src/funtracks/import_export/geff/_import.py
@@ -309,27 +309,16 @@ class GeffTracksBuilder(TracksBuilder):
         self,
         source_path: Path,
         node_name_map: dict[str, str | list[str]],
-        node_features: dict[str, bool] | None = None,
     ) -> None:
         """Load GEFF data and convert to InMemoryGeff format.
 
         Args:
             source_path: Path to GEFF zarr store
             node_name_map: Maps standard keys to GEFF property names
-            node_features: Optional features dict (handled by import_graph_from_geff)
         """
-        # For backward compatibility, extend node_name_map with node_features
-        # Only add features that should be loaded (recompute=False)
-        extended_name_map = dict(node_name_map)
-        if node_features is not None:
-            for feature_key, recompute in node_features.items():
-                if feature_key not in extended_name_map and not recompute:
-                    # Assume feature name in GEFF matches standard key
-                    extended_name_map[feature_key] = feature_key
-
         # Load GEFF data with renamed properties (returns InMemoryGeff with standard keys)
         self.in_memory_geff, self.position_attr, ndim = import_graph_from_geff(
-            source_path, extended_name_map, edge_name_map=self.edge_name_map
+            source_path, node_name_map, edge_name_map=self.edge_name_map
         )
         # Only set ndim if not already set from segmentation
         if self.ndim is None:
@@ -341,12 +330,7 @@ def import_from_geff(
     node_name_map: dict[str, str | list[str]] | None = None,
     segmentation_path: Path | None = None,
     scale: list[float] | None = None,
-    node_features: dict[str, bool] | None = None,
-    edge_features: dict[str, bool] | None = None,
-    extra_features: dict[str, bool] | None = None,
     edge_name_map: dict[str, str | list[str]] | None = None,
-    edge_prop_filter: list[str] | None = None,
-    name_map: dict[str, str | list[str]] | None = None,  # deprecated
     database: str | None = None,
 ) -> SolutionTracks:
     """Import tracks from GEFF format.
@@ -362,53 +346,14 @@ def import_from_geff(
             If None, property names are auto-inferred using fuzzy matching.
         segmentation_path: Optional path to segmentation data
         scale: Optional spatial scale
-        node_features: Optional node features to enable/load
-        edge_features: Optional edge features to enable/load
-        extra_features: (Deprecated) Use node_features instead. Kept for
-            backward compatibility.
         edge_name_map: Optional mapping from standard funtracks keys to GEFF
             edge property names. Example: {"iou": "overlap"}
-        edge_prop_filter: (Deprecated) Use edge_name_map instead. Kept for
-            backward compatibility.
-        name_map: Deprecated. Use node_name_map instead.
         database: Optional path to a SQLite database file for backing storage.
             If None (default), an in-memory/temp graph is used.
 
     Returns:
         SolutionTracks object
-
-    Raises:
-        ValueError: If both node_features and extra_features are provided
     """
-    from warnings import warn
-
-    # Handle deprecated name_map parameter
-    if name_map is not None:
-        warn(
-            "name_map is deprecated, use node_name_map instead",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        if node_name_map is None:
-            node_name_map = name_map
-
-    # Handle backward compatibility: extra_features -> node_features
-    if extra_features is not None and node_features is not None:
-        raise ValueError(
-            "Cannot specify both 'node_features' and 'extra_features'. "
-            "Please use 'node_features' (extra_features is deprecated)."
-        )
-    if extra_features is not None:
-        node_features = extra_features
-
-    # Handle backward compatibility: edge_prop_filter -> edge_name_map
-    # edge_prop_filter was a list of property names to load
-    # edge_name_map is a dict mapping standard keys to GEFF property names
-    # If edge_prop_filter is provided, convert it to edge_name_map format
-    if edge_prop_filter is not None and edge_name_map is None:
-        # Map each property to itself (no renaming, just filtering)
-        edge_name_map = {prop: prop for prop in edge_prop_filter}
-
     # Filter out None values and "None" strings from node_name_map
     # (e.g., {"lineage_id": None} or {"lineage_id": "None"})
     if node_name_map is not None:
@@ -432,8 +377,6 @@ def import_from_geff(
         directory,
         segmentation_path,
         scale=scale,
-        node_features=node_features,
-        edge_features=edge_features,
         node_name_map=node_name_map,
         database=database,
     )

--- a/tests/import_export/test_csv_import.py
+++ b/tests/import_export/test_csv_import.py
@@ -269,35 +269,18 @@ class TestFeatureHandling:
             }
         )
 
-        tracks = tracks_from_df(df, features={"Area": "area"})
+        node_name_map = {
+            "id": "id",
+            "parent_id": "parent_id",
+            "time": "time",
+            "pos": ["y", "x"],
+            "area": "area",
+        }
+        tracks = tracks_from_df(df, node_name_map=node_name_map)
 
         # Area should be loaded from DataFrame
         assert tracks.get_node_attr(1, "area") == 100.0
         assert tracks.get_node_attr(2, "area") == 200.0
-
-    def test_recompute_area_from_seg(self):
-        """Test recomputing area from segmentation."""
-        df = pd.DataFrame(
-            {
-                "time": [0, 1],
-                "y": [10.0, 20.0],
-                "x": [15.0, 25.0],
-                "id": [1, 2],
-                "parent_id": [-1, 1],
-                "seg_id": [1, 2],  # Required when segmentation provided
-            }
-        )
-
-        # Create segmentation with known areas
-        seg = np.zeros((2, 100, 100), dtype=np.uint16)
-        seg[0, 8:13, 13:18] = 1  # 5x5 = 25 pixels
-        seg[1, 18:23, 23:28] = 2  # 5x5 = 25 pixels
-
-        tracks = tracks_from_df(df, seg, features={"Area": "Recompute"})
-
-        # Area should be computed from segmentation
-        assert tracks.get_node_attr(1, "area") == 25
-        assert tracks.get_node_attr(2, "area") == 25
 
     def test_load_multi_value_feature_from_columns(self):
         """Test loading a multi-value feature from separate columns."""

--- a/tests/import_export/test_import_from_geff.py
+++ b/tests/import_export/test_import_from_geff.py
@@ -300,17 +300,17 @@ def test_tracks_with_segmentation(valid_geff, invalid_geff, valid_segmentation, 
 
     # Test that a tracks object is produced and that the seg_id has been relabeled.
     scale = [1, 1, (1 / 100)]
-    node_features = {
-        "area": True,  # In geff, but should be recomputed
-        "random_feature": False,  # Static feature - load from geff
+    name_map_with_features = {
+        **name_map,
+        "area": "area",
+        "random_feature": "random_feature",
     }
 
     tracks = import_from_geff(
         store,
-        name_map,
+        name_map_with_features,
         segmentation_path=valid_segmentation_path,
         scale=scale,
-        node_features=node_features,
     )
     assert hasattr(tracks, "segmentation")
     assert tracks.segmentation.shape == valid_segmentation.shape
@@ -331,33 +331,12 @@ def test_tracks_with_segmentation(valid_geff, invalid_geff, valid_segmentation, 
         np.asarray(tracks.segmentation)[tuple(coords)] == last_node
     )  # test that the seg id has been relabeled
 
-    # Check that only required/requested features are present, and that area is recomputed
+    # Check that only requested features are present and area is loaded from geff
     data = tracks.graph.nodes[last_node]
     assert "random_feature" in tracks.graph.node_attr_keys()
     assert "random_feature2" not in tracks.graph.node_attr_keys()
     assert "area" in tracks.graph.node_attr_keys()
-    assert (
-        data["area"] == 0.01
-    )  # recomputed area values should be 1 pixel, so 0.01 after applying the scaling.
-
-    # Check that area is not recomputed but taken directly from the graph
-    node_features = {
-        "area": False,  # Load from geff, don't recompute
-        "random_feature": False,  # Static feature - load from geff
-    }
-
-    tracks = import_from_geff(
-        store,
-        name_map,
-        segmentation_path=valid_segmentation_path,
-        scale=scale,
-        node_features=node_features,
-    )
-    # Get last node by ID (don't rely on iteration order)
-    last_node = max(tracks.graph.node_ids())
-    data = tracks.graph.nodes[last_node]
-    assert "area" in tracks.graph.node_attr_keys()
-    assert data["area"] == 21
+    assert data["area"] == 21  # loaded directly from geff, not recomputed
 
     # Test that import fails with ValueError when invalid seg_ids are provided.
     store, _ = invalid_geff
@@ -394,58 +373,46 @@ def test_segmentation_loading_formats(
     else:
         raise ValueError(f"Unknown format: {segmentation_format}")
 
-    node_features = {
-        "area": False,  # Load from geff, don't recompute
-        "random_feature": False,  # Static feature - load from geff
+    name_map_with_features = {
+        **name_map,
+        "area": "area",
+        "random_feature": "random_feature",
     }
 
     tracks = import_from_geff(
         store,
-        name_map,
+        name_map_with_features,
         segmentation_path=path,
         scale=scale,
-        node_features=node_features,
     )
 
     assert hasattr(tracks, "segmentation")
     assert np.array(tracks.segmentation).shape == seg.shape
 
 
-def test_node_features_compute_vs_load(valid_geff, valid_segmentation, tmp_path):
-    """Test that node_features controls whether features are computed or loaded.
-
-    Features marked True in node_features are computed using annotators.
-    Features marked False are loaded directly from the geff file.
-    Features not in the geff can still be computed if marked True.
-    """
+def test_features_loaded_from_name_map(valid_geff, valid_segmentation, tmp_path):
+    """Test that features included in node_name_map are loaded and registered."""
     store, _ = valid_geff
     node_name_map = {
         "time": "t",
-        "pos": ["y", "x"],  # Composite position mapping
+        "pos": ["y", "x"],
         "seg_id": "seg_id",
         "circularity": "circ",  # Map standard key to GEFF property name
+        "area": "area",  # Load area from geff
+        "random_feature": "random_feature",  # Static feature - load from geff
     }
     scale = [1, 1, 1 / 100]
     valid_segmentation_path = tmp_path / "segmentation.tif"
     tifffile.imwrite(valid_segmentation_path, valid_segmentation)
-
-    # Test 1: Mix of computed (True) and loaded (False) features
-    node_features = {
-        "area": True,  # In geff, but should be recomputed
-        "random_feature": False,  # Static feature - load from geff
-        "circularity": False,  # In geff, load without recomputing
-        "ellipse_axis_radii": True,  # Not in geff, should be computed
-    }
 
     tracks = import_from_geff(
         store,
         node_name_map,
         segmentation_path=valid_segmentation_path,
         scale=scale,
-        node_features=node_features,
     )
 
-    feature_keys = ["area", "random_feature", "ellipse_axis_radii", "circularity"]
+    feature_keys = ["area", "random_feature", "circularity"]
     for key in feature_keys:
         assert key in tracks.features
 
@@ -453,68 +420,26 @@ def test_node_features_compute_vs_load(valid_geff, valid_segmentation, tmp_path)
     max_node_id = max(tracks.graph.node_ids())
     data = tracks.graph.nodes[max_node_id]
 
-    # All requested features should be present
+    # All requested features should be present and loaded from geff
     for key in feature_keys:
         assert data[key] is not None
 
-    # Verify computed values (1 pixel = 0.01 after scaling)
-    # Original geff had area=21 for last node
-    assert data["area"] == 0.01
-    assert data["ellipse_axis_radii"] is not None
-    assert data["circularity"] == 0.45  # the value should not be recomputed
-
-    # Verify loaded value from geff
-    assert data["random_feature"] == "e"
+    assert data["area"] == 21  # loaded from geff
+    assert data["circularity"] == 0.45  # loaded from geff (renamed from "circ")
+    assert data["random_feature"] == "e"  # static feature loaded from geff
 
 
-def test_node_features_unknown(valid_geff, valid_segmentation, tmp_path):
-    """Test that providing an unknown feature raises a KeyError."""
+def test_nonexistent_property_in_name_map(valid_geff):
+    """Test that mapping to a non-existent GEFF property raises an error."""
     store, _ = valid_geff
-    name_map = {"time": "t", "pos": ["y", "x"], "seg_id": "seg_id"}
-    scale = [1, 1, 1 / 100]
-    valid_segmentation_path = tmp_path / "segmentation.tif"
-    tifffile.imwrite(valid_segmentation_path, valid_segmentation)
-
-    # Test unknown feature that doesn't exist in annotators or GEFF
-    node_features = {
-        "unknown_computed_feature": True,  # Unknown feature, request computation
+    node_name_map = {
+        "time": "t",
+        "pos": ["y", "x"],
+        "area": "nonexistent_column",  # This property doesn't exist in the GEFF
     }
 
-    with pytest.raises(
-        KeyError,
-        match="Node features not available",
-    ):
-        import_from_geff(
-            store,
-            name_map,
-            segmentation_path=valid_segmentation_path,
-            scale=scale,
-            node_features=node_features,
-        )
-
-
-def test_compute_features_without_segmentation(valid_geff):
-    """Test that computing regionprops features without segmentation raises an error."""
-    store, _ = valid_geff
-    name_map = {"time": "t", "pos": ["y", "x"]}
-    scale = [1, 1, 1 / 100]
-
-    # Try to compute area feature without providing segmentation
-    node_features = {
-        "area": True,  # Request computation without segmentation
-    }
-
-    with pytest.raises(
-        KeyError,
-        match="Node features not available",
-    ):
-        import_from_geff(
-            store,
-            name_map,
-            segmentation_path=None,  # No segmentation
-            scale=scale,
-            node_features=node_features,
-        )
+    with pytest.raises(ValueError):
+        import_from_geff(store, node_name_map)
 
 
 def _make_mask(bbox):


### PR DESCRIPTION
@TeunHuijben I think this is the version of this code that should go into main, with all the deprecations removed and all features enabled from the name_map. I didn't add the edge_name_map argument, but we should and could here if we wanted. Can you take a quick look if you get the chance? 🙏 