### PR TITLE
Fix benchmark CI failing due to symlink conflict with mike docs deployment

### DIFF
--- a/.github/workflows/benchmark-report.yml
+++ b/.github/workflows/benchmark-report.yml
@@ -37,5 +37,6 @@ jobs:
           name: Python Benchmark with pytest-benchmark
           tool: 'pytest'
           output-file-path: output.json
+          benchmark-data-dir-path: benchmarks
           github-token: ${{ secrets.GITHUB_TOKEN }}
           auto-push: true


### PR DESCRIPTION
**Problem**
The benchmark-report.yml workflow stores benchmark results to the gh-pages branch using benchmark-action/github-action-benchmark, which defaults to writing at dev/bench/data.js. However, dev in gh-pages is a symlink created by mike (our versioned docs tool) pointing to the current docs version directory. Git refuses to add files inside a symlinked path, causing the error:


fatal: pathspec 'dev/bench/data.js' is beyond a symbolic link
This broke the benchmark CI on every push to main after the benchmark workflow was introduced.

**Fix**
Override the default storage path by setting benchmark-data-dir-path: benchmarks in the action config. This writes benchmark data to a plain directory (benchmarks/) in gh-pages that is not managed by mike, so git can write to it without conflict.

The benchmark dashboard will be available at:
https://funkelab.github.io/funtracks/benchmarks/