### PR TITLE
fix: register RegionpropsAnnotator before enable_features

### DIFF
--- a/src/funtracks/import_export/geff/_import.py
+++ b/src/funtracks/import_export/geff/_import.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 from geff._typing import InMemoryGeff
 from geff.core_io._base_read import read_to_memory
@@ -233,77 +233,88 @@ class GeffTracksBuilder(TracksBuilder):
         # Fall back to fuzzy matching when axes metadata is absent or incomplete
         return super().infer_node_name_map()
 
-    def build(self, *args, **kwargs):
-        """Build SolutionTracks and reconstruct Mask objects and segmentation.
+    def enable_features(
+        self,
+        tracks: SolutionTracks,
+        name_map: dict[str, str | list[str]],
+        feature_type: Literal["node", "edge"] = "node",
+    ) -> None:
+        """Reconstruct embedded segmentation, then delegate to the parent.
 
-        The geff format serialises mask data as plain numeric arrays (zarr cannot
-        store arbitrary Python objects). After loading we post-process every node
-        that carries both a ``mask`` and a ``bbox`` attribute and wrap the raw array
-        back into a :class:`tracksdata.nodes.Mask` instance, exactly as
-        tracksdata's own ``from_geff`` does.
+        The GEFF format serialises mask data as plain numeric arrays (zarr cannot
+        store arbitrary Python objects).  Before enabling node features, this
+        override wraps each raw array back into a
+        :class:`tracksdata.nodes.Mask` instance and, when a
+        ``segmentation_shape`` was written to the zarr attrs during export,
+        reconstructs the dense segmentation as a
+        :class:`tracksdata.array.GraphArrayView` and registers a
+        :class:`~funtracks.annotators.RegionpropsAnnotator`.
 
-        Additionally, if ``segmentation_shape`` was written to the zarr attrs during
-        export, restore it in the graph metadata and reconstruct the segmentation
-        as a :class:`tracksdata.array.GraphArrayView`.
+        Doing this inside ``enable_features()`` — rather than after
+        ``super().build()`` returns — means the annotator is present when the
+        parent processes the name map, so multi-value features such as
+        ``ellipse_axis_radii`` are registered with their correct metadata
+        (``num_values=2``, ``spatial_dims=True``, ``value_names``) rather than
+        being silently downgraded to a static scalar feature.
+        """
+        if feature_type == "node":
+            self._setup_embedded_segmentation(tracks)
+        super().enable_features(tracks, name_map, feature_type=feature_type)
+
+    def _setup_embedded_segmentation(self, tracks: SolutionTracks) -> None:
+        """Reconstruct Mask objects and segmentation from embedded GEFF data.
+
+        Idempotent: guards on ``tracks.segmentation is None`` and the absence of
+        an existing :class:`~funtracks.annotators.RegionpropsAnnotator`.
         """
         import tracksdata as td
         from tracksdata.array import GraphArrayView
         from tracksdata.nodes import Mask
 
-        tracks = super().build(*args, **kwargs)
-
         mask_key = td.DEFAULT_ATTR_KEYS.MASK
         bbox_key = td.DEFAULT_ATTR_KEYS.BBOX
         graph = tracks.graph
 
-        if mask_key in graph.node_attr_keys() and bbox_key in graph.node_attr_keys():
-            df = graph.node_attrs(attr_keys=[mask_key, bbox_key])
-            node_ids = list(graph.node_ids())
-            nodes_to_update = []
-            new_masks = []
-            for node_id, mask_val, bbox_val in zip(
-                node_ids, df[mask_key], df[bbox_key], strict=True
-            ):
-                if not isinstance(mask_val, Mask):
-                    nodes_to_update.append(node_id)
-                    new_masks.append(Mask(mask_val.astype(bool), bbox=bbox_val))
+        if (
+            mask_key not in graph.node_attr_keys()
+            or bbox_key not in graph.node_attr_keys()
+        ):
+            return
 
-            if nodes_to_update:
-                graph.update_node_attrs(
-                    attrs={mask_key: new_masks},
-                    node_ids=nodes_to_update,
+        df = graph.node_attrs(attr_keys=[mask_key, bbox_key])
+        node_ids = list(graph.node_ids())
+        nodes_to_update = []
+        new_masks = []
+        for node_id, mask_val, bbox_val in zip(
+            node_ids, df[mask_key], df[bbox_key], strict=True
+        ):
+            if not isinstance(mask_val, Mask):
+                nodes_to_update.append(node_id)
+                new_masks.append(Mask(mask_val.astype(bool), bbox=bbox_val))
+
+        if nodes_to_update:
+            graph.update_node_attrs(
+                attrs={mask_key: new_masks},
+                node_ids=nodes_to_update,
+            )
+
+        seg_shape = getattr(self, "_segmentation_shape", None)
+        if seg_shape is not None and tracks.segmentation is None:
+            graph._update_metadata(segmentation_shape=seg_shape)
+            tracks.segmentation = GraphArrayView(
+                graph=graph,
+                shape=seg_shape,
+                attr_key="node_id",
+                offset=0,
+            )
+            if not any(isinstance(a, RegionpropsAnnotator) for a in tracks.annotators):
+                pos_key = (
+                    tracks.features.position_key
+                    if isinstance(tracks.features.position_key, str)
+                    else None
                 )
-
-            # Reconstruct segmentation from segmentation_shape written by export_to_geff.
-            # Tracks.__init__ already ran (segmentation=None because graph metadata
-            # was not yet populated), so we create the GraphArrayView directly.
-            seg_shape = getattr(self, "_segmentation_shape", None)
-            if seg_shape is not None and tracks.segmentation is None:
-                graph._update_metadata(segmentation_shape=seg_shape)
-                tracks.segmentation = GraphArrayView(
-                    graph=graph,
-                    shape=seg_shape,
-                    attr_key="node_id",
-                    offset=0,
-                )
-                # RegionpropsAnnotator was not created during __init__ because
-                # segmentation was None at that point. Now that segmentation is
-                # available, add it so that newly painted cells get their position
-                # and area computed correctly.
-                if not any(
-                    isinstance(a, RegionpropsAnnotator) for a in tracks.annotators
-                ):
-                    pos_key = (
-                        tracks.features.position_key
-                        if isinstance(tracks.features.position_key, str)
-                        else None
-                    )
-                    tracks.annotators.append(
-                        RegionpropsAnnotator(tracks, pos_key=pos_key)
-                    )
-                    tracks._setup_core_computed_features()
-
-        return tracks
+                tracks.annotators.append(RegionpropsAnnotator(tracks, pos_key=pos_key))
+                tracks._setup_core_computed_features()
 
     def load_source(
         self,

--- a/src/funtracks/import_export/geff/_import.py
+++ b/src/funtracks/import_export/geff/_import.py
@@ -253,8 +253,15 @@ class GeffTracksBuilder(TracksBuilder):
 
         mask_key = td.DEFAULT_ATTR_KEYS.MASK
         bbox_key = td.DEFAULT_ATTR_KEYS.BBOX
+        has_mask = mask_key in graph.node_attr_keys()
+        has_bbox = bbox_key in graph.node_attr_keys()
+        if has_mask != has_bbox:
+            raise ValueError(
+                f"GEFF graph has only one of '{mask_key}'/'{bbox_key}'; "
+                "both are required for mask reconstruction."
+            )
 
-        if mask_key in graph.node_attr_keys() and bbox_key in graph.node_attr_keys():
+        if has_mask:
             # Reconstruct Mask objects from raw numeric arrays
             df = graph.node_attrs(attr_keys=[mask_key, bbox_key])
             node_ids = list(graph.node_ids())
@@ -276,9 +283,8 @@ class GeffTracksBuilder(TracksBuilder):
         # Write segmentation_shape into graph metadata so that
         # Tracks.__init__ can reconstruct the segmentation and the
         # RegionpropsAnnotator is created during _get_annotators().
-        seg_shape = getattr(self, "_segmentation_shape", None)
-        if seg_shape is not None:
-            graph._update_metadata(segmentation_shape=seg_shape)
+        if self._segmentation_shape is not None:
+            graph._update_metadata(segmentation_shape=self._segmentation_shape)
 
         return graph
 

--- a/src/funtracks/import_export/geff/_import.py
+++ b/src/funtracks/import_export/geff/_import.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING
 
+import tracksdata as td
 from geff._typing import InMemoryGeff
 from geff.core_io._base_read import read_to_memory
-
-from funtracks.annotators import RegionpropsAnnotator
+from tracksdata.nodes import Mask
 
 from .._tracks_builder import TracksBuilder, flatten_name_map
 
@@ -233,88 +233,54 @@ class GeffTracksBuilder(TracksBuilder):
         # Fall back to fuzzy matching when axes metadata is absent or incomplete
         return super().infer_node_name_map()
 
-    def enable_features(
+    def construct_graph(
         self,
-        tracks: SolutionTracks,
-        name_map: dict[str, str | list[str]],
-        feature_type: Literal["node", "edge"] = "node",
-    ) -> None:
-        """Reconstruct embedded segmentation, then delegate to the parent.
+        node_name_map: dict[str, str | list[str]] | None = None,
+        database: str | None = None,
+    ) -> td.graph.GraphView:
+        """Construct graph and prepare embedded segmentation data.
 
-        The GEFF format serialises mask data as plain numeric arrays (zarr cannot
-        store arbitrary Python objects).  Before enabling node features, this
-        override wraps each raw array back into a
-        :class:`tracksdata.nodes.Mask` instance and, when a
-        ``segmentation_shape`` was written to the zarr attrs during export,
-        reconstructs the dense segmentation as a
-        :class:`tracksdata.array.GraphArrayView` and registers a
-        :class:`~funtracks.annotators.RegionpropsAnnotator`.
-
-        Doing this inside ``enable_features()`` — rather than after
-        ``super().build()`` returns — means the annotator is present when the
-        parent processes the name map, so multi-value features such as
-        ``ellipse_axis_radii`` are registered with their correct metadata
-        (``num_values=2``, ``spatial_dims=True``, ``value_names``) rather than
-        being silently downgraded to a static scalar feature.
+        The GEFF format serialises mask data as plain numeric arrays (zarr
+        cannot store arbitrary Python objects).  After the base graph is built,
+        this override wraps each raw array back into a
+        :class:`tracksdata.nodes.Mask` instance and writes
+        ``segmentation_shape`` into the graph metadata so that
+        :class:`~funtracks.data_model.tracks.Tracks.__init__` can reconstruct
+        the segmentation and create the
+        :class:`~funtracks.annotators.RegionpropsAnnotator` naturally.
         """
-        if feature_type == "node":
-            self._setup_embedded_segmentation(tracks)
-        super().enable_features(tracks, name_map, feature_type=feature_type)
-
-    def _setup_embedded_segmentation(self, tracks: SolutionTracks) -> None:
-        """Reconstruct Mask objects and segmentation from embedded GEFF data.
-
-        Idempotent: guards on ``tracks.segmentation is None`` and the absence of
-        an existing :class:`~funtracks.annotators.RegionpropsAnnotator`.
-        """
-        import tracksdata as td
-        from tracksdata.array import GraphArrayView
-        from tracksdata.nodes import Mask
+        graph = super().construct_graph(node_name_map, database=database)
 
         mask_key = td.DEFAULT_ATTR_KEYS.MASK
         bbox_key = td.DEFAULT_ATTR_KEYS.BBOX
-        graph = tracks.graph
 
-        if (
-            mask_key not in graph.node_attr_keys()
-            or bbox_key not in graph.node_attr_keys()
-        ):
-            return
+        if mask_key in graph.node_attr_keys() and bbox_key in graph.node_attr_keys():
+            # Reconstruct Mask objects from raw numeric arrays
+            df = graph.node_attrs(attr_keys=[mask_key, bbox_key])
+            node_ids = list(graph.node_ids())
+            nodes_to_update = []
+            new_masks = []
+            for node_id, mask_val, bbox_val in zip(
+                node_ids, df[mask_key], df[bbox_key], strict=True
+            ):
+                if not isinstance(mask_val, Mask):
+                    nodes_to_update.append(node_id)
+                    new_masks.append(Mask(mask_val.astype(bool), bbox=bbox_val))
 
-        df = graph.node_attrs(attr_keys=[mask_key, bbox_key])
-        node_ids = list(graph.node_ids())
-        nodes_to_update = []
-        new_masks = []
-        for node_id, mask_val, bbox_val in zip(
-            node_ids, df[mask_key], df[bbox_key], strict=True
-        ):
-            if not isinstance(mask_val, Mask):
-                nodes_to_update.append(node_id)
-                new_masks.append(Mask(mask_val.astype(bool), bbox=bbox_val))
-
-        if nodes_to_update:
-            graph.update_node_attrs(
-                attrs={mask_key: new_masks},
-                node_ids=nodes_to_update,
-            )
-
-        seg_shape = getattr(self, "_segmentation_shape", None)
-        if seg_shape is not None and tracks.segmentation is None:
-            graph._update_metadata(segmentation_shape=seg_shape)
-            tracks.segmentation = GraphArrayView(
-                graph=graph,
-                shape=seg_shape,
-                attr_key="node_id",
-                offset=0,
-            )
-            if not any(isinstance(a, RegionpropsAnnotator) for a in tracks.annotators):
-                pos_key = (
-                    tracks.features.position_key
-                    if isinstance(tracks.features.position_key, str)
-                    else None
+            if nodes_to_update:
+                graph.update_node_attrs(
+                    attrs={mask_key: new_masks},
+                    node_ids=nodes_to_update,
                 )
-                tracks.annotators.append(RegionpropsAnnotator(tracks, pos_key=pos_key))
-                tracks._setup_core_computed_features()
+
+        # Write segmentation_shape into graph metadata so that
+        # Tracks.__init__ can reconstruct the segmentation and the
+        # RegionpropsAnnotator is created during _get_annotators().
+        seg_shape = getattr(self, "_segmentation_shape", None)
+        if seg_shape is not None:
+            graph._update_metadata(segmentation_shape=seg_shape)
+
+        return graph
 
     def load_source(
         self,

--- a/tests/import_export/test_import_from_geff.py
+++ b/tests/import_export/test_import_from_geff.py
@@ -783,3 +783,89 @@ def test_3d_pos_survives_sql_roundtrip(tmp_path):
         "This likely means construct_graph() used the wrong ndim when registering "
         "the pos schema, causing a mismatch with the actual 3-element data."
     )
+
+
+def test_embedded_seg_ellipse_axis_radii_feature_metadata(tmp_path):
+    """Regression: ellipse_axis_radii must have correct Feature metadata after
+    round-tripping through a GEFF with embedded segmentation.
+
+    TracksBuilder.enable_features() hardcodes num_values=1 for static features.
+    When the RegionpropsAnnotator is absent at build step 8 (embedded-seg case),
+    ellipse_axis_radii is registered as a static feature instead of an
+    annotator-managed one, producing wrong metadata: num_values=1 instead of 2,
+    no spatial_dims flag, and no value_names.
+    """
+    import tracksdata as td
+
+    node_attributes = [
+        "pos",
+        "area",
+        "ellipse_axis_radii",
+        "track_id",
+        "lineage_id",
+        td.DEFAULT_ATTR_KEYS.MASK,
+        td.DEFAULT_ATTR_KEYS.BBOX,
+    ]
+    # node_default_values must align with node_attributes by index.
+    # pos/track_id/mask/bbox are handled by special cases in create_empty_graphview_graph
+    # and their slot values here are never accessed; only area, ellipse_axis_radii,
+    # and lineage_id go through the general loop.
+    node_default_values = [
+        None,  # pos — special-cased, slot unused
+        0.0,  # area
+        np.array([0.0, 0.0]),  # ellipse_axis_radii — must be Array(Float64, 2)
+        None,  # track_id — special-cased, slot unused
+        -1,  # lineage_id
+        None,  # mask — special-cased, slot unused
+        None,  # bbox — special-cased, slot unused
+    ]
+    graph = create_empty_graphview_graph(
+        node_attributes=node_attributes,
+        node_default_values=node_default_values,
+        edge_attributes=[],
+        ndim=3,
+    )
+    bbox = [20, 20, 50, 60]
+    graph.bulk_add_nodes(
+        nodes=[
+            {
+                "t": 0,
+                "pos": np.array([35.0, 40.0]),
+                "area": 900.0,
+                "ellipse_axis_radii": np.array([20.0, 15.0]),
+                "track_id": 1,
+                "lineage_id": 1,
+                "solution": 1,
+                td.DEFAULT_ATTR_KEYS.MASK: _make_mask(bbox),
+                td.DEFAULT_ATTR_KEYS.BBOX: np.array(bbox, dtype=np.int64),
+            }
+        ],
+        indices=[1],
+    )
+    graph._update_metadata(segmentation_shape=(3, 100, 100))
+
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+
+    st = SolutionTracks(graph, ndim=3, time_attr="t")
+    export_to_geff(st, run_dir)
+
+    imported = import_from_geff(run_dir / "tracks.geff")
+
+    assert "ellipse_axis_radii" in imported.features, (
+        "ellipse_axis_radii should be registered as a feature after import"
+    )
+    feat = imported.features["ellipse_axis_radii"]
+    assert feat["num_values"] == 2, (
+        f"ellipse_axis_radii num_values should be 2, got {feat['num_values']}. "
+        "Likely cause: registered as a static feature (hardcoded num_values=1) "
+        "because RegionpropsAnnotator was absent when enable_features() ran at "
+        "build step 8 of GeffTracksBuilder.build()."
+    )
+    assert feat.get("spatial_dims") is True, (
+        f"ellipse_axis_radii spatial_dims should be True, got {feat.get('spatial_dims')}"
+    )
+    assert feat.get("value_names") == ["major_axis", "minor_axis"], (
+        f"ellipse_axis_radii value_names should be ['major_axis', 'minor_axis'], "
+        f"got {feat.get('value_names')}"
+    )

--- a/tests/import_export/test_import_from_geff.py
+++ b/tests/import_export/test_import_from_geff.py
@@ -797,6 +797,8 @@ def test_embedded_seg_ellipse_axis_radii_feature_metadata(tmp_path):
     """
     import tracksdata as td
 
+    from funtracks.annotators import RegionpropsAnnotator
+
     node_attributes = [
         "pos",
         "area",
@@ -851,6 +853,12 @@ def test_embedded_seg_ellipse_axis_radii_feature_metadata(tmp_path):
     export_to_geff(st, run_dir)
 
     imported = import_from_geff(run_dir / "tracks.geff")
+
+    assert any(isinstance(a, RegionpropsAnnotator) for a in imported.annotators), (
+        "RegionpropsAnnotator should be present after import of an embedded-seg "
+        "GEFF. Without it, regionprops features get wrong metadata via the "
+        "static-feature fallback in TracksBuilder.enable_features()."
+    )
 
     assert "ellipse_axis_radii" in imported.features, (
         "ellipse_axis_radii should be registered as a feature after import"


### PR DESCRIPTION
When importing a GEFF with embedded segmentation, `GeffTracksBuilder` used to register the `RegionpropsAnnotator` *after* `super().build()` returned — but `enable_features()` runs *inside* `super().build()`. This meant the annotator wasn't present when features were registered from the name map, so multi-value features like `ellipse_axis_radii` were silently stored as static scalar features (`num_values=1` instead of `2`, no `spatial_dims`, no `value_names`).

Real reason for this PR: 
In **motile_tracker**, the import dialog has a "Recompute" checkbox for regionprops features. For the embedded-segmentation case this checkbox was intentionally disabled, because calling tracks.enable_features(["area"], recompute=True) after import would crash with KeyError: Features not available — the RegionpropsAnnotator was simply not in tracks.annotators at that point. The UI workaround masked the underlying ordering bug in funtracks.

## Fix

Override `enable_features()` in `GeffTracksBuilder`. The mask reconstruction and annotator setup now happen at the start of that call, before the parent processes the name map — so the annotator is present when each feature is registered and gets its correct metadata.

## Test

`test_embedded_seg_ellipse_axis_radii_feature_metadata` — round-trips a GEFF with embedded segmentation and asserts that `ellipse_axis_radii` has `num_values=2`, `spatial_dims=True`, and `value_names=["major_axis", "minor_axis"]` after import. This test failed before the fix and passes after.