### PR TITLE
stop auto-computing area

### DIFF
--- a/src/funtracks/data_model/tracks.py
+++ b/src/funtracks/data_model/tracks.py
@@ -323,36 +323,40 @@ class Tracks:
         For each core feature:
         - Activates any features listed that are detected to exist (without computing)
         - Enables any features that don't exist (compute fresh)
+
+        Area is treated differently: it is activated if already present on the graph
+        but is NOT computed from scratch. Users must call enable_features(["area"])
+        explicitly to compute area for a graph that does not already have it.
         """
         # Import here to avoid circular dependency
         from funtracks.annotators import RegionpropsAnnotator, TrackAnnotator
 
-        # Register core features from annotators in the features dict
-        core_computed_features: list[str] = []
+        # (key, compute_if_missing) pairs: True = compute if not on graph,
+        # False = activate only if already on graph
+        core_features: list[tuple[str, bool]] = []
         for annotator in self.annotators:
             if isinstance(annotator, RegionpropsAnnotator):
                 pos_key = annotator.pos_key
                 if self.features.position_key is None:
                     self.features.position_key = pos_key
-                core_computed_features.append(pos_key)
-                # special case for backward compatibility
-                core_computed_features.append("area")
+                core_features.append((pos_key, True))
+                # area: activate if present but don't compute from scratch
+                core_features.append(("area", False))
             elif isinstance(annotator, TrackAnnotator):
                 tracklet_key = annotator.tracklet_key
                 self.features.tracklet_key = tracklet_key
-                core_computed_features.append(tracklet_key)
+                core_features.append((tracklet_key, True))
                 lineage_key = annotator.lineage_key
                 self.features.lineage_key = lineage_key
-                core_computed_features.append(lineage_key)
-        for key in core_computed_features:
+                core_features.append((lineage_key, True))
+        for key, compute_if_missing in core_features:
             if self._check_existing_feature(key):
                 # Add to FeatureDict if not already there
                 if key not in self.features:
                     feature, _ = self.annotators.all_features[key]
                     self.add_feature(key, feature)
                 self.annotators.activate_features([key])
-            else:
-                # enable it (compute it)
+            elif compute_if_missing:
                 self.enable_features([key])
 
     def nodes(self):

--- a/src/funtracks/data_model/tracks.py
+++ b/src/funtracks/data_model/tracks.py
@@ -315,46 +315,38 @@ class Tracks:
         return key in node_attrs
 
     def _setup_core_computed_features(self) -> None:
-        """Sets up the core computed features (area, position, tracklet if applicable)
+        """Sets up core computed features (position, tracklet, lineage).
 
-        Registers position/tracklet features from annotators into FeatureDict
-        For each core feature:
-        - Activates any features listed that are detected to exist (without computing)
-        - Enables any features that don't exist (compute fresh)
-
-        Area is treated differently: it is activated if already present on the graph
-        but is NOT computed from scratch. Users must call enable_features(["area"])
-        explicitly to compute area for a graph that does not already have it.
+        Registers position/tracklet/lineage features from annotators into
+        FeatureDict.  For each core feature:
+        - Activates any features that are detected to already exist on the graph
+        - Enables (computes) any features that don't exist yet
         """
         # Import here to avoid circular dependency
         from funtracks.annotators import RegionpropsAnnotator, TrackAnnotator
 
-        # (key, compute_if_missing) pairs: True = compute if not on graph,
-        # False = activate only if already on graph
-        core_features: list[tuple[str, bool]] = []
+        core_features: list[str] = []
         for annotator in self.annotators:
             if isinstance(annotator, RegionpropsAnnotator):
                 pos_key = annotator.pos_key
                 if self.features.position_key is None:
                     self.features.position_key = pos_key
-                core_features.append((pos_key, True))
-                # area: activate if present but don't compute from scratch
-                core_features.append(("area", False))
+                core_features.append(pos_key)
             elif isinstance(annotator, TrackAnnotator):
                 tracklet_key = annotator.tracklet_key
                 self.features.tracklet_key = tracklet_key
-                core_features.append((tracklet_key, True))
+                core_features.append(tracklet_key)
                 lineage_key = annotator.lineage_key
                 self.features.lineage_key = lineage_key
-                core_features.append((lineage_key, True))
-        for key, compute_if_missing in core_features:
+                core_features.append(lineage_key)
+        for key in core_features:
             if self._check_existing_feature(key):
                 # Add to FeatureDict if not already there
                 if key not in self.features:
                     feature, _ = self.annotators.all_features[key]
                     self.add_feature(key, feature)
                 self.annotators.activate_features([key])
-            elif compute_if_missing:
+            else:
                 self.enable_features([key])
 
     def nodes(self):

--- a/src/funtracks/data_model/tracks.py
+++ b/src/funtracks/data_model/tracks.py
@@ -92,7 +92,7 @@ class Tracks:
                 definitions. If provided, time_attr/pos_attr/tracklet_attr are ignored.
                 Assumes that all features in the dict already exist on the graph (will
                 be activated but not recomputed). If None, core computed features (pos,
-                area, track_id) are auto-detected by checking if they exist on the graph.
+                track_id) are auto-detected by checking if they exist on the graph.
             _segmentation (GraphArrayView | None): Internal parameter for reusing an
                 existing GraphArrayView instance. Not intended for public use.
         """
@@ -341,7 +341,6 @@ class Tracks:
                 core_features.append(lineage_key)
         for key in core_features:
             if self._check_existing_feature(key):
-                # Add to FeatureDict if not already there
                 if key not in self.features:
                     feature, _ = self.annotators.all_features[key]
                     self.add_feature(key, feature)

--- a/tests/annotators/test_annotator_registry.py
+++ b/tests/annotators/test_annotator_registry.py
@@ -60,19 +60,18 @@ def test_enable_disable_features(graph_2d_with_segmentation):
     nodes = list(tracks.graph.node_ids())
     edges = list(tracks.graph.edge_ids())
 
-    # Core features (time, pos, area) should be in tracks.features and computed
+    # Core features (time, pos) should be in tracks.features and computed
     assert "pos" in tracks.features
     assert "t" in tracks.features
-    assert "area" in tracks.features  # Core feature for backward compatibility
     assert tracks.graph.nodes[nodes[0]]["pos"] is not None
-    assert tracks.graph.nodes[nodes[0]]["area"] is not None
 
-    # Other features should NOT be in tracks.features initially
+    # area and other features should NOT be in tracks.features initially
+    assert "area" not in tracks.features
     assert "iou" not in tracks.features
     assert "circularity" not in tracks.features
 
     # Enable multiple features at once
-    tracks.enable_features(["iou", "circularity"])
+    tracks.enable_features(["area", "iou", "circularity"])
 
     # Features should now be in FeatureDict
     assert "iou" in tracks.features

--- a/tests/annotators/test_annotator_registry.py
+++ b/tests/annotators/test_annotator_registry.py
@@ -101,6 +101,25 @@ def test_enable_disable_features(graph_2d_with_segmentation):
     assert "circularity" not in tracks.features
 
 
+def test_area_on_graph_not_auto_activated(graph_2d_with_segmentation):
+    """Area pre-populated on a raw graph must not be auto-activated.
+
+    Lock in the behavior introduced when area was removed from the core
+    auto-detected features: even though the graph already carries area values,
+    Tracks(graph) without an explicit FeatureDict must leave area out of
+    tracks.features. Callers opt in via enable_features(["area"]).
+    """
+    assert "area" in graph_2d_with_segmentation.node_attr_keys()
+
+    tracks = Tracks(graph_2d_with_segmentation, ndim=3, **track_attrs)
+
+    assert "area" not in tracks.features
+    assert "area" in tracks.annotators.all_features
+
+    tracks.enable_features(["area"])
+    assert "area" in tracks.features
+
+
 def test_get_available_features(graph_2d_with_segmentation):
     """Test get_available_features returns all features from all annotators."""
     tracks = SolutionTracks(

--- a/tests/annotators/test_regionprops_annotator.py
+++ b/tests/annotators/test_regionprops_annotator.py
@@ -100,6 +100,8 @@ class TestRegionpropsAnnotator:
         )
         all_feature_keys = list(rp_ann.all_features.keys())
         to_remove_key = all_feature_keys[1]  # area
+        # area is not auto-enabled, so enable it first before testing disable
+        tracks.enable_features([to_remove_key])
         tracks.disable_features([to_remove_key])
 
         rp_ann.compute()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,13 +17,6 @@ if TYPE_CHECKING:
 
     from funtracks.data_model import SolutionTracks, Tracks
 
-# Feature list constants for consistent test usage
-# WITH_SEG means segmentation stored as mask/bbox node attributes
-FEATURES_WITH_SEG = ["pos", "area", "iou", "mask", "bbox"]
-FEATURES_NO_SEG = ["pos"]
-SOLUTION_FEATURES_WITH_SEG = ["pos", "area", "iou", "track_id", "mask", "bbox"]
-SOLUTION_FEATURES_NO_SEG = ["pos", "track_id"]
-
 
 def make_2d_disk_mask(center=(50, 50), radius=20) -> Mask:
     """Create a 2D disk mask with bounding box.

--- a/tests/data_model/test_solution_tracks.py
+++ b/tests/data_model/test_solution_tracks.py
@@ -119,6 +119,7 @@ def test_export_to_csv_with_display_names(
     """Test CSV export with use_display_names=True option."""
     # Test 2D with display names
     tracks = SolutionTracks(graph_2d_with_segmentation, **track_attrs, ndim=3)
+    tracks.enable_features(["area"])
     temp_file = tmp_path / "test_export_2d_display.csv"
     export_to_csv(tracks, temp_file, use_display_names=True)
     with open(temp_file) as f:
@@ -126,12 +127,13 @@ def test_export_to_csv_with_display_names(
 
     assert len(lines) == tracks.graph.num_nodes() + 1  # add header
 
-    # With display names: ID, Parent ID, Time, y, x, Tracklet ID, Lineage ID
-    header = ["ID", "Parent ID", "Time", "y", "x", "Area", "Tracklet ID", "Lineage ID"]
+    # With display names: ID, Parent ID, Time, y, x, Tracklet ID, Lineage ID, Area
+    header = ["ID", "Parent ID", "Time", "y", "x", "Tracklet ID", "Lineage ID", "Area"]
     assert lines[0].strip().split(",") == header
 
-    # Test 3D with display names
+    # Test 3D with display names (area display name is "Volume" in 3D)
     tracks = SolutionTracks(graph_3d_with_segmentation, **track_attrs, ndim=4)
+    tracks.enable_features(["area"])
     temp_file = tmp_path / "test_export_3d_display.csv"
     export_to_csv(tracks, temp_file, use_display_names=True)
     with open(temp_file) as f:
@@ -139,7 +141,7 @@ def test_export_to_csv_with_display_names(
 
     assert len(lines) == tracks.graph.num_nodes() + 1  # add header
 
-    # With display names: ID, Parent ID, Time, z, y, x, Tracklet ID, Lineage ID
+    # With display names: ID, Parent ID, Time, z, y, x, Tracklet ID, Lineage ID, Volume
     header = [
         "ID",
         "Parent ID",
@@ -147,9 +149,9 @@ def test_export_to_csv_with_display_names(
         "z",
         "y",
         "x",
-        "Volume",
         "Tracklet ID",
         "Lineage ID",
+        "Volume",
     ]
     assert lines[0].strip().split(",") == header
 


### PR DESCRIPTION
**The problem**: The original code auto-computed `area` from scratch on `Tracks` initialization (if it wasn't already on the graph nodes). Commenting out the `core_computed_features.append("area")` line entirely broke the case where `area` *was* already on the graph — it would no longer be registered in `tracks.features` or activated in the annotator.

**The fix**: Replace the single list with a list of `(key, compute_if_missing)` tuples. `area` gets `compute_if_missing=False`, meaning:
- If `area` is already on the graph → activated and added to `tracks.features` (backward compat for files that have area)
- If `area` is **not** on the graph → skipped; caller must use `enable_features(["area"])` explicitly

```python
# (key, compute_if_missing) pairs
core_features: list[tuple[str, bool]] = []
...
core_features.append((pos_key, True))
core_features.append(("area", False))   # activate if present, never compute from scratch
...
for key, compute_if_missing in core_features:
    if self._check_existing_feature(key):
        ...
        self.annotators.activate_features([key])
    elif compute_if_missing:
        self.enable_features([key])
```




Closes #193 