### PR TITLE
rename track_id to tracklet_id for consistency

### DIFF
--- a/src/funtracks/annotators/_annotator_registry.py
+++ b/src/funtracks/annotators/_annotator_registry.py
@@ -19,7 +19,7 @@ class AnnotatorRegistry(list[GraphAnnotator]):
         annotators = AnnotatorRegistry([
             RegionpropsAnnotator(tracks, pos_key="centroid"),
             EdgeAnnotator(tracks),
-            TrackAnnotator(tracks, tracklet_key="track_id"),
+            TrackAnnotator(tracks, tracklet_key=DEFAULT_TRACKLET_KEY),
         ])
 
         # Can use as a list

--- a/src/funtracks/annotators/_track_annotator.py
+++ b/src/funtracks/annotators/_track_annotator.py
@@ -8,7 +8,6 @@ import rustworkx as rx
 import tracksdata as td
 
 from funtracks.actions import AddNode, DeleteNode, UpdateTrackIDs
-from funtracks.data_model import SolutionTracks
 from funtracks.features import LineageID, TrackletID
 
 from ._graph_annotator import GraphAnnotator
@@ -17,6 +16,7 @@ if TYPE_CHECKING:
     from collections.abc import Iterable
 
     from funtracks.actions import BasicAction
+    from funtracks.data_model import SolutionTracks
     from funtracks.features import Feature
 
 
@@ -64,6 +64,8 @@ class TrackAnnotator(GraphAnnotator):
         Returns:
             True if tracks is a SolutionTracks instance, False otherwise
         """
+        from funtracks.data_model import SolutionTracks
+
         return isinstance(tracks, SolutionTracks)
 
     @classmethod
@@ -91,6 +93,8 @@ class TrackAnnotator(GraphAnnotator):
         tracklet_key: str | None = DEFAULT_TRACKLET_KEY,
         lineage_key: str | None = DEFAULT_LINEAGE_KEY,
     ):
+        from funtracks.data_model import SolutionTracks
+
         if not isinstance(tracks, SolutionTracks):
             raise ValueError("Currently the TrackAnnotator only works on SolutionTracks")
 
@@ -198,15 +202,15 @@ class TrackAnnotator(GraphAnnotator):
         Each connected component will get a unique id, and the relevant class
         attributes will be updated.
         """
+        # Materialise the internal -> external node-id mapping once. On
+        # tracksdata-backed graphs every call to graph.node_ids() walks the
+        # bidict, so calling it inside the per-component loop is O(n) per node.
+        node_id_map = self.tracks.graph.node_ids()
 
         lineages_internal = rx.weakly_connected_components(self.tracks.graph.rx_graph)
-        lineages_external = []
-        for lin in lineages_internal:
-            node_ids_internal = list(lin)
-            node_ids_external = [
-                self.tracks.graph.node_ids()[nid] for nid in node_ids_internal
-            ]
-            lineages_external.append(node_ids_external)
+        lineages_external = [
+            [node_id_map[nid] for nid in lin] for lin in lineages_internal
+        ]
 
         max_id, ids_to_nodes = self._assign_ids(lineages_external, self.lineage_key)
         self.max_lineage_id = max_id
@@ -220,28 +224,30 @@ class TrackAnnotator(GraphAnnotator):
         """
         graph_copy = self.tracks.graph.detach().filter().subgraph()
 
-        parents = [
-            node
-            for node, degree in zip(
-                self.tracks.graph.node_ids(), self.tracks.graph.out_degree(), strict=True
-            )
-            if degree >= 2
-        ]
+        # Hoist O(n) graph queries out of the per-parent / per-tracklet loops.
+        # On tracksdata-backed graphs each node_ids() / edge_list() call walks
+        # the bidict, so doing this inside the inner loops is O(n^2) overall.
+        src_node_ids = self.tracks.graph.node_ids()
+        out_degrees = self.tracks.graph.out_degree()
+        parents = [n for n, d in zip(src_node_ids, out_degrees, strict=True) if d >= 2]
+
+        # Build parent -> daughters once instead of scanning edge_list per parent.
+        children: dict[int, list[int]] = {}
+        for src, tgt in self.tracks.graph.edge_list():
+            children.setdefault(src, []).append(tgt)
 
         # Remove all intertrack edges from a copy of the original graph
         for parent in parents:
-            all_edges = self.tracks.graph.edge_list()
-            daughters = [edge[1] for edge in all_edges if edge[0] == parent]
-
-            for daughter in daughters:
+            for daughter in children.get(parent, ()):
                 graph_copy.remove_edge(parent, daughter)
+
+        copy_node_id_map = graph_copy.node_ids()
 
         track_id = 1
         all_node_ids = []
         all_track_ids = []
         for tracklet in rx.weakly_connected_components(graph_copy.rx_graph):
-            node_ids_internal = list(tracklet)
-            node_ids_external = [graph_copy.node_ids()[nid] for nid in node_ids_internal]
+            node_ids_external = [copy_node_id_map[nid] for nid in tracklet]
             all_node_ids.extend(node_ids_external)
             all_track_ids.extend([track_id] * len(node_ids_external))
             self.tracklet_id_to_nodes[track_id] = node_ids_external

--- a/src/funtracks/data_model/tracks.py
+++ b/src/funtracks/data_model/tracks.py
@@ -17,10 +17,19 @@ from tracksdata.array import GraphArrayView
 from tracksdata.nodes import Mask
 
 from funtracks.actions.action_history import ActionHistory
+from funtracks.annotators._track_annotator import (
+    DEFAULT_LINEAGE_KEY,
+    DEFAULT_TRACKLET_KEY,
+)
 from funtracks.features import Feature, FeatureDict, Position, Time
 from funtracks.utils.tracksdata_utils import (
     to_polars_dtype,
 )
+
+# Pre-2.0 default attribute name for tracklet IDs. Retained as a fallback so
+# data persisted under the old key (CSV/GEFF/Zarr) continues to load without
+# triggering a silent recompute.
+LEGACY_TRACKLET_KEY = "track_id"
 
 if TYPE_CHECKING:
     import tracksdata as td
@@ -81,7 +90,7 @@ class Tracks:
                 - List/tuple of strings for multi-axis (one attribute per axis)
                 Defaults to "pos" if None.
             tracklet_attr (str | None): Graph attribute name for tracklet/track IDs.
-                Defaults to "track_id" if None.
+                Defaults to DEFAULT_TRACKLET_KEY if None.
             lineage_attr (str | None): Graph attribute name for lineage IDs.
                 Defaults to "lineage_id" if None.
             scale (list[float] | None): Scaling factors for each dimension (including
@@ -186,10 +195,10 @@ class Tracks:
                 - Single string: one attribute containing position array (e.g., "pos")
                 - List/tuple: multiple attributes, one per axis (e.g., ["y", "x"])
                 - None: defaults to "pos"
-            tracklet_key: Graph attribute name for tracklet/track IDs (e.g., "track_id").
-                If None, defaults to "track_id"
-            lineage_key: Graph attribute name for lineage IDs (e.g., "lineage_id").
-                if None, defaults to "lineage_id"
+            tracklet_key: Graph attribute name for tracklet/track IDs.
+                If None, defaults to DEFAULT_TRACKLET_KEY.
+            lineage_key: Graph attribute name for lineage IDs.
+                If None, defaults to DEFAULT_LINEAGE_KEY.
 
         Returns:
             FeatureDict initialized with time feature and position if no segmentation
@@ -199,9 +208,9 @@ class Tracks:
         if pos_attr is None:
             pos_attr = "pos"
         if tracklet_key is None:
-            tracklet_key = "track_id"
+            tracklet_key = DEFAULT_TRACKLET_KEY
         if lineage_key is None:
-            lineage_key = "lineage_id"
+            lineage_key = DEFAULT_LINEAGE_KEY
 
         # Build static features dict - always include time
         features: dict[str, Feature] = {time_key: Time()}
@@ -324,6 +333,19 @@ class Tracks:
         """
         # Import here to avoid circular dependency
         from funtracks.annotators import RegionpropsAnnotator, TrackAnnotator
+
+        # Backward compatibility: if the TrackAnnotator was configured with the
+        # canonical key but the graph still holds tracklets under the pre-2.0
+        # legacy key ("track_id"), swap the annotator over to the legacy key so
+        # the existing data is auto-detected instead of silently recomputed.
+        graph_attrs = set(self.graph.node_attr_keys())
+        for annotator in self.annotators:
+            if (
+                isinstance(annotator, TrackAnnotator)
+                and annotator.tracklet_key not in graph_attrs
+                and LEGACY_TRACKLET_KEY in graph_attrs
+            ):
+                annotator.change_key(annotator.tracklet_key, LEGACY_TRACKLET_KEY)
 
         # Register core features from annotators in the features dict
         core_computed_features: list[str] = []

--- a/src/funtracks/import_export/_export_segmentation.py
+++ b/src/funtracks/import_export/_export_segmentation.py
@@ -8,6 +8,7 @@ import numpy as np
 import tifffile
 from tracksdata.array import GraphArrayView
 
+from funtracks.annotators._track_annotator import DEFAULT_TRACKLET_KEY
 from funtracks.utils import setup_zarr_array
 
 if TYPE_CHECKING:
@@ -20,7 +21,7 @@ def export_segmentation(
     tracks: Tracks,
     output_path: Path,
     file_format: Literal["zarr", "tiff"] = "zarr",
-    label_attr: str | None = "track_id",
+    label_attr: str | None = DEFAULT_TRACKLET_KEY,
     zarr_format: Literal[2, 3] = 2,
     node_ids: set[int] | None = None,
 ) -> None:
@@ -35,9 +36,9 @@ def export_segmentation(
             For tiff, a .tif file will be written.
         file_format: Output format, either "zarr" or "tiff". Defaults to "zarr".
         label_attr: Node attribute used to paint cell labels. When set, each cell is
-            painted with the value of this attribute (e.g. "track_id"). When None,
-            the original segmentation labels (node IDs) are preserved as-is.
-            Defaults to "track_id".
+            painted with the value of this attribute (e.g. DEFAULT_TRACKLET_KEY).
+            When None, the original segmentation labels (node IDs) are preserved
+            as-is. Defaults to DEFAULT_TRACKLET_KEY.
         zarr_format: Zarr format version. Only used when file_format="zarr".
             Defaults to 2.
         node_ids: Optional subset of node IDs to include. Cells not in this set

--- a/src/funtracks/import_export/_tracks_builder.py
+++ b/src/funtracks/import_export/_tracks_builder.py
@@ -15,6 +15,10 @@ import numpy as np
 import tracksdata as td
 from geff._typing import InMemoryGeff
 
+from funtracks.annotators._track_annotator import (
+    DEFAULT_LINEAGE_KEY,
+    DEFAULT_TRACKLET_KEY,
+)
 from funtracks.data_model.solution_tracks import SolutionTracks
 from funtracks.features import Feature
 from funtracks.import_export._import_segmentation import (
@@ -92,7 +96,6 @@ def flatten_name_map(
 
 
 # defining constants here because they are only used in the context of import
-TRACK_KEY = "track_id"
 SEG_KEY = "seg_id"
 
 
@@ -743,10 +746,23 @@ class TracksBuilder(ABC):
         # 7. Create SolutionTracks
         # construct_graph() always stores time as "t" (tracksdata convention),
         # regardless of TIME_ATTR, so we pass "t" here explicitly.
+        # Propagate the tracklet/lineage key actually present in the source data,
+        # so that auto-detection in _setup_core_computed_features finds the
+        # existing column instead of silently recomputing under the default key.
+        # Accepts both the canonical DEFAULT_TRACKLET_KEY and the legacy "track_id".
+        node_props = self.in_memory_geff["node_props"]
+        tracklet_attr: str | None = None
+        for candidate in (DEFAULT_TRACKLET_KEY, "track_id"):
+            if candidate in node_props:
+                tracklet_attr = candidate
+                break
+        lineage_attr = DEFAULT_LINEAGE_KEY if DEFAULT_LINEAGE_KEY in node_props else None
         tracks = SolutionTracks(
             graph=graph,
             pos_attr="pos",
             time_attr="t",
+            tracklet_attr=tracklet_attr,
+            lineage_attr=lineage_attr,
             ndim=self.ndim,
             scale=scale,
         )

--- a/src/funtracks/import_export/_validation.py
+++ b/src/funtracks/import_export/_validation.py
@@ -14,6 +14,11 @@ from geff.validate.graph import (
 from geff.validate.segmentation import has_seg_ids_at_coords
 from geff.validate.tracks import validate_lineages, validate_tracklets
 
+from funtracks.annotators._track_annotator import (
+    DEFAULT_LINEAGE_KEY,
+    DEFAULT_TRACKLET_KEY,
+)
+
 if TYPE_CHECKING:
     import dask.array as da
 
@@ -410,26 +415,30 @@ def validate_in_memory_geff(in_memory_geff: InMemoryGeff) -> None:
     if not valid:
         raise ValueError(f"Repeated edges found in data:\n{invalid_edges}")
 
-    # Validate tracklet_id if present (optional - remove if invalid)
-    if "track_id" in node_props:
-        tracklet_ids = node_props["track_id"]["values"]
-        valid, errors = validate_tracklets(node_ids, edge_ids, tracklet_ids)
-        if not valid:
-            warn(
-                f"track_id validation failed:\n{chr(10).join(errors)}\n"
-                "Removing track_id from data.",
-                stacklevel=2,
-            )
-            del node_props["track_id"]
+    # Validate tracklet_id if present (optional - remove if invalid).
+    # Accept the legacy "track_id" spelling as well, so files persisted under
+    # the pre-2.0 default key continue to validate.
+    for tracklet_key in (DEFAULT_TRACKLET_KEY, "track_id"):
+        if tracklet_key in node_props:
+            tracklet_ids = node_props[tracklet_key]["values"]
+            valid, errors = validate_tracklets(node_ids, edge_ids, tracklet_ids)
+            if not valid:
+                warn(
+                    f"{tracklet_key} validation failed:\n{chr(10).join(errors)}\n"
+                    f"Removing {tracklet_key} from data.",
+                    stacklevel=2,
+                )
+                del node_props[tracklet_key]
+            break
 
     # Validate lineage_id if present (optional - remove if invalid)
-    if "lineage_id" in node_props:
-        lineage_ids = node_props["lineage_id"]["values"]
+    if DEFAULT_LINEAGE_KEY in node_props:
+        lineage_ids = node_props[DEFAULT_LINEAGE_KEY]["values"]
         valid, errors = validate_lineages(node_ids, edge_ids, lineage_ids)
         if not valid:
             warn(
-                f"lineage_id validation failed:\n{chr(10).join(errors)}\n"
-                "Removing lineage_id from data.",
+                f"{DEFAULT_LINEAGE_KEY} validation failed:\n{chr(10).join(errors)}\n"
+                f"Removing {DEFAULT_LINEAGE_KEY} from data.",
                 stacklevel=2,
             )
-            del node_props["lineage_id"]
+            del node_props[DEFAULT_LINEAGE_KEY]

--- a/src/funtracks/import_export/csv/_export.py
+++ b/src/funtracks/import_export/csv/_export.py
@@ -8,6 +8,8 @@ from typing import TYPE_CHECKING, Any, Literal, cast
 import numpy as np
 import pandas as pd
 
+from funtracks.annotators._track_annotator import DEFAULT_TRACKLET_KEY
+
 from .._export_segmentation import export_segmentation
 from .._utils import filter_graph_with_ancestors
 
@@ -23,7 +25,7 @@ def export_to_csv(
     use_display_names: bool = False,
     export_seg: bool = False,
     seg_path: Path | str | None = None,
-    seg_label_attr: str | None = "track_id",
+    seg_label_attr: str | None = DEFAULT_TRACKLET_KEY,
     seg_file_format: Literal["zarr", "tiff"] = "zarr",
     zarr_format: Literal[2, 3] = 2,
 ) -> None:
@@ -47,8 +49,8 @@ def export_to_csv(
         export_seg: Whether to export the segmentation alongside the CSV.
         seg_path: Path to save the segmentation to. Required when export_seg=True.
         seg_label_attr: Node attribute used to paint cell labels in the exported
-            segmentation. Defaults to "track_id". When None, original segmentation
-            labels (node IDs) are preserved.
+            segmentation. Defaults to DEFAULT_TRACKLET_KEY. When None, original
+            segmentation labels (node IDs) are preserved.
         seg_file_format: Output format for the segmentation, either "zarr" or "tiff".
             Defaults to "zarr".
         zarr_format: Zarr format version. Only used when seg_file_format="zarr".
@@ -61,7 +63,7 @@ def export_to_csv(
         >>> export_to_csv(tracks, "output.csv", use_display_names=True)
         >>> # Export only specific nodes
         >>> export_to_csv(tracks, "filtered.csv", node_ids={1, 2, 3})
-        >>> # Export with segmentation as zarr painted by track_id
+        >>> # Export with segmentation as zarr painted by tracklet_id
         >>> export_to_csv(tracks, "out.csv", export_seg=True, seg_path="seg_zarr")
         >>> # Export with segmentation as tiff, original labels
         >>> export_to_csv(tracks, "out.csv", export_seg=True, seg_path="seg.tif",
@@ -98,10 +100,10 @@ def export_to_csv(
         column_map["coords"] = coords
 
         # identifiers
-        header.extend(["id", "parent_id", "track_id"])
+        header.extend(["id", "parent_id", DEFAULT_TRACKLET_KEY])
         column_map["id"] = "id"
         column_map["parent_id"] = "parent_id"
-        column_map["track_id"] = "track_id"
+        column_map[DEFAULT_TRACKLET_KEY] = DEFAULT_TRACKLET_KEY
 
     # For display names mode, build dynamic header from features
     feature_names = []
@@ -175,7 +177,9 @@ def export_to_csv(
             for name, value in zip(column_map["coords"], pos, strict=True):
                 row[name] = convert_numpy_to_python(value)
 
-            row[cast(str, column_map["track_id"])] = tracks.get_track_id(node_id)
+            row[cast(str, column_map[DEFAULT_TRACKLET_KEY])] = tracks.get_track_id(
+                node_id
+            )
 
         rows.append(row)
 
@@ -201,10 +205,10 @@ def export_to_csv(
 
         df_colors = pd.DataFrame(
             list(track_id_to_hex.items()),  # convert dict to list of (track_id, hex)
-            columns=[column_map["track_id"], "Tracklet ID Color"],
+            columns=[column_map[DEFAULT_TRACKLET_KEY], "Tracklet ID Color"],
         )
 
-        df = pd.merge(df, df_colors, how="left", on=[column_map["track_id"]])
+        df = pd.merge(df, df_colors, how="left", on=[column_map[DEFAULT_TRACKLET_KEY]])
 
     df.to_csv(outfile, index=False)
 

--- a/src/funtracks/import_export/csv/_import.py
+++ b/src/funtracks/import_export/csv/_import.py
@@ -13,6 +13,11 @@ from geff_spec.utils import (
     create_props_metadata,
 )
 
+from funtracks.annotators._track_annotator import (
+    DEFAULT_LINEAGE_KEY,
+    DEFAULT_TRACKLET_KEY,
+)
+
 from .._tracks_builder import TracksBuilder, flatten_name_map
 
 if TYPE_CHECKING:
@@ -162,12 +167,15 @@ class CSVTracksBuilder(TracksBuilder):
             metadata, node_props_metadata, c_type="node"
         )
 
-        # Set track_node_props if we have track_id or lineage_id
+        # Set track_node_props if we have a tracklet/lineage column.
+        # Accept the legacy "track_id" spelling for backward compatibility.
         track_node_props = {}
-        if "track_id" in node_props:
-            track_node_props["tracklet"] = "track_id"
-        if "lineage_id" in node_props:
-            track_node_props["lineage"] = "lineage_id"
+        for tracklet_key in (DEFAULT_TRACKLET_KEY, "track_id"):
+            if tracklet_key in node_props:
+                track_node_props["tracklet"] = tracklet_key
+                break
+        if DEFAULT_LINEAGE_KEY in node_props:
+            track_node_props["lineage"] = DEFAULT_LINEAGE_KEY
         if track_node_props:
             metadata.track_node_props = track_node_props
 

--- a/src/funtracks/import_export/geff/_export.py
+++ b/src/funtracks/import_export/geff/_export.py
@@ -10,6 +10,7 @@ import polars as pl
 import tracksdata as td
 from geff_spec import GeffMetadata
 
+from funtracks.annotators._track_annotator import DEFAULT_TRACKLET_KEY
 from funtracks.utils import remove_tilde, setup_zarr_group
 
 from .._export_segmentation import export_segmentation
@@ -28,7 +29,7 @@ def export_to_geff(
     node_ids: set[int] | None = None,
     zarr_format: Literal[2, 3] = 2,
     save_segmentation: bool = True,
-    seg_label_attr: str | None = "track_id",
+    seg_label_attr: str | None = DEFAULT_TRACKLET_KEY,
     seg_file_format: Literal["zarr", "tiff"] = "zarr",
 ):
     """Export the Tracks graph to geff.
@@ -45,8 +46,8 @@ def export_to_geff(
         save_segmentation (bool): If True, saves the segmentation array alongside
             the graph when segmentation is present. Defaults to True.
         seg_label_attr (str | None): Node attribute used to paint cell labels in the
-            exported segmentation. Defaults to "track_id". When None, original
-            segmentation labels (node IDs) are preserved.
+            exported segmentation. Defaults to DEFAULT_TRACKLET_KEY. When None,
+            original segmentation labels (node IDs) are preserved.
         seg_file_format: Output format for the segmentation, either "zarr" or "tiff".
             Defaults to "zarr".
     """

--- a/src/funtracks/import_export/geff/_import.py
+++ b/src/funtracks/import_export/geff/_import.py
@@ -16,7 +16,6 @@ if TYPE_CHECKING:
 
 
 # defining constants here because they are only used in the context of import
-TRACK_KEY = "track_id"
 SEG_KEY = "seg_id"
 
 

--- a/src/funtracks/utils/tracksdata_utils.py
+++ b/src/funtracks/utils/tracksdata_utils.py
@@ -153,8 +153,14 @@ def create_empty_graphview_graph(
         graph_td.add_node_attr_key("mask", pl.Object)
     if "bbox" in (node_attributes or []):
         graph_td.add_node_attr_key("bbox", pl.Array(pl.Int64, 2 * (ndim - 1)))
-    if "track_id" in (node_attributes or []):
-        graph_td.add_node_attr_key("track_id", default_value=-1, dtype=pl.Int64)
+    # Register the tracklet attribute under whichever key the caller asked for.
+    # Both the canonical DEFAULT_TRACKLET_KEY ("tracklet_id") and the legacy
+    # spelling ("track_id") are recognised so save/load of pre-2.0 graphs works.
+    from funtracks.annotators._track_annotator import DEFAULT_TRACKLET_KEY
+
+    for tracklet_key in (DEFAULT_TRACKLET_KEY, "track_id"):
+        if tracklet_key in (node_attributes or []):
+            graph_td.add_node_attr_key(tracklet_key, default_value=-1, dtype=pl.Int64)
 
     for attr in node_attributes or []:
         if attr not in graph_td.node_attr_keys():

--- a/tests/actions/test_action_history.py
+++ b/tests/actions/test_action_history.py
@@ -9,12 +9,14 @@ from funtracks.utils.tracksdata_utils import create_empty_graphview_graph
 def test_action_history():
     history = ActionHistory()
     empty_graph = create_empty_graphview_graph(
-        node_attributes=["track_id", "pos"],
+        node_attributes=["tracklet_id", "pos"],
         edge_attributes=[],
     )
-    tracks = SolutionTracks(empty_graph, ndim=3, tracklet_attr="track_id", time_attr="t")
+    tracks = SolutionTracks(
+        empty_graph, ndim=3, tracklet_attr="tracklet_id", time_attr="t"
+    )
     pos = [0, 1]
-    action1 = AddNode(tracks, node=0, attributes={"t": 0, "pos": pos, "track_id": 1})
+    action1 = AddNode(tracks, node=0, attributes={"t": 0, "pos": pos, "tracklet_id": 1})
 
     # empty history has no undo or redo
     assert not history.undo()
@@ -44,7 +46,7 @@ def test_action_history():
 
     # undo and then add new action
     assert history.undo()
-    action2 = AddNode(tracks, node=10, attributes={"t": 10, "pos": pos, "track_id": 2})
+    action2 = AddNode(tracks, node=10, attributes={"t": 10, "pos": pos, "tracklet_id": 2})
     history.add_new_action(action2)
     assert tracks.graph.num_nodes() == 1
     # there are 3 things on the stack: action1, action1's inverse, and action 2

--- a/tests/actions/test_add_delete_edge.py
+++ b/tests/actions/test_add_delete_edge.py
@@ -176,7 +176,7 @@ def test_add_edge_with_unregistered_edge_attr(tmp_path):
     # This mirrors what the motile solver does: it writes edge attributes directly
     # to the graph without going through tracks.add_feature().
     graph = create_empty_graphview_graph(
-        node_attributes=["pos", "track_id", "lineage_id"],
+        node_attributes=["pos", "tracklet_id", "lineage_id"],
         edge_attributes=["custom_score"],
         database=db_path,
         position_attrs=["pos"],
@@ -185,8 +185,20 @@ def test_add_edge_with_unregistered_edge_attr(tmp_path):
 
     graph.bulk_add_nodes(
         nodes=[
-            {"t": 0, "pos": [10.0, 10.0], "track_id": 1, "lineage_id": 1, "solution": 1},
-            {"t": 1, "pos": [11.0, 11.0], "track_id": 2, "lineage_id": 1, "solution": 1},
+            {
+                "t": 0,
+                "pos": [10.0, 10.0],
+                "tracklet_id": 1,
+                "lineage_id": 1,
+                "solution": 1,
+            },
+            {
+                "t": 1,
+                "pos": [11.0, 11.0],
+                "tracklet_id": 2,
+                "lineage_id": 1,
+                "solution": 1,
+            },
         ],
         indices=[1, 2],
     )
@@ -197,12 +209,12 @@ def test_add_edge_with_unregistered_edge_attr(tmp_path):
         features={
             "t": Time(),
             "pos": Position(axes=["y", "x"]),
-            "track_id": TrackletID(),
+            "tracklet_id": TrackletID(),
             "lineage_id": LineageID(),
         },
         time_key="t",
         position_key="pos",
-        tracklet_key="track_id",
+        tracklet_key="tracklet_id",
         lineage_key="lineage_id",
     )
     tracks = SolutionTracks(graph, ndim=3, features=features)

--- a/tests/actions/test_add_delete_nodes.py
+++ b/tests/actions/test_add_delete_nodes.py
@@ -127,8 +127,8 @@ def test_add_node_missing_time(get_tracks):
 
 def test_add_node_missing_pos(get_tracks):
     tracks = get_tracks(ndim=3, with_seg=True, is_solution=True)
-    # First test: missing track_id raises an error
-    with pytest.raises(ValueError, match="Must provide a track_id attribute for node"):
+    # First test: missing tracklet_id raises an error
+    with pytest.raises(ValueError, match="Must provide a tracklet_id attribute for node"):
         AddNode(tracks, 8, {"t": 2})
 
     # Second test: with track_id but without segmentation, missing pos raises an error
@@ -136,7 +136,7 @@ def test_add_node_missing_pos(get_tracks):
     with pytest.raises(
         ValueError, match="Must provide position or segmentation for node"
     ):
-        AddNode(tracks_no_seg, 8, {"t": 2, "track_id": 1})
+        AddNode(tracks_no_seg, 8, {"t": 2, "tracklet_id": 1})
 
 
 @pytest.mark.parametrize("ndim", [3, 4])
@@ -177,7 +177,7 @@ def test_custom_attributes_preserved(get_tracks, ndim, with_seg):
     # Define attributes including custom ones
     custom_attrs = {
         "t": 2,
-        "track_id": 10,
+        "tracklet_id": 10,
         "pos": [50.0, 50.0] if ndim == 3 else [50.0, 50.0, 50.0],
         # Custom user attributes
         "cell_type": "neuron",

--- a/tests/actions/test_update_node_attrs.py
+++ b/tests/actions/test_update_node_attrs.py
@@ -30,7 +30,7 @@ def test_update_node_attrs(get_tracks, ndim):
     assert tracks.get_node_attr(node, "score") == 1.0
 
 
-@pytest.mark.parametrize("attr", ["t", "area", "track_id"])
+@pytest.mark.parametrize("attr", ["t", "area", "tracklet_id"])
 def test_update_protected_attr(get_tracks, attr):
     tracks = get_tracks(ndim=3, with_seg=True, is_solution=True)
     with pytest.raises(ValueError, match="Cannot update attribute .* manually"):

--- a/tests/annotators/test_track_annotator.py
+++ b/tests/annotators/test_track_annotator.py
@@ -23,7 +23,7 @@ class TestTrackAnnotator:
         assert len(ann.features) == 0
         assert len(ann.lineage_id_to_nodes) == 2
 
-        ann = TrackAnnotator(tracks, tracklet_key="track_id")
+        ann = TrackAnnotator(tracks, tracklet_key="tracklet_id")
         assert len(ann.all_features) == 2
         assert len(ann.features) == 0
         assert len(ann.lineage_id_to_nodes) == 2
@@ -178,7 +178,7 @@ class TestTrackAnnotator:
         # ---- Add a node with existing track id ----
         # After the split, only node 3 has track_id=3, and it has lineage_id=1
         # (nodes 4,5 got new track_id=6 and lineage_id=3)
-        attrs = {"pos": ([5, 8]), tracks.features.time_key: (5), "track_id": (3)}
+        attrs = {"pos": ([5, 8]), tracks.features.time_key: (5), "tracklet_id": (3)}
         UserAddNode(tracks, node=7, attributes=attrs)
 
         # Assert new node adopts lineage of existing track (track_id=3 -> lineage_id=1)
@@ -186,7 +186,7 @@ class TestTrackAnnotator:
         assert 7 in ann.lineage_id_to_nodes[1]
 
         # ---- Add a node with a new track id ----
-        attrs = {"pos": ([5, 8]), tracks.features.time_key: (5), "track_id": (4)}
+        attrs = {"pos": ([5, 8]), tracks.features.time_key: (5), "tracklet_id": (4)}
         expected_lineage_id = ann.max_lineage_id + 1
         UserAddNode(tracks, node=8, attributes=attrs)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,8 +21,8 @@ if TYPE_CHECKING:
 # WITH_SEG means segmentation stored as mask/bbox node attributes
 FEATURES_WITH_SEG = ["pos", "area", "iou", "mask", "bbox"]
 FEATURES_NO_SEG = ["pos"]
-SOLUTION_FEATURES_WITH_SEG = ["pos", "area", "iou", "track_id", "mask", "bbox"]
-SOLUTION_FEATURES_NO_SEG = ["pos", "track_id"]
+SOLUTION_FEATURES_WITH_SEG = ["pos", "area", "iou", "tracklet_id", "mask", "bbox"]
+SOLUTION_FEATURES_NO_SEG = ["pos", "tracklet_id"]
 
 
 def make_2d_disk_mask(center=(50, 50), radius=20) -> Mask:
@@ -162,7 +162,7 @@ def _make_graph(
     if with_pos:
         node_attributes.append("pos")
     if with_track_id:
-        node_attributes.append("track_id")
+        node_attributes.append("tracklet_id")
         node_attributes.append("lineage_id")
     if with_area:
         node_attributes.append("area")
@@ -251,7 +251,7 @@ def _make_graph(
             # TODO: don't hardcode "pos" and other column names
             node_attrs["pos"] = positions[node_id]
         if with_track_id:
-            node_attrs["track_id"] = track_ids[node_id]
+            node_attrs["tracklet_id"] = track_ids[node_id]
             node_attrs["lineage_id"] = lineage_ids[node_id]
         if with_area:
             node_attrs["area"] = float(areas[node_id])
@@ -398,14 +398,14 @@ def get_tracks(get_graph) -> Callable[..., "Tracks | SolutionTracks"]:
             features_dict["area"] = Area(ndim=ndim)
             features_dict["iou"] = IoU()
         if is_solution:
-            features_dict["track_id"] = TrackletID()
+            features_dict["tracklet_id"] = TrackletID()
             features_dict["lineage_id"] = LineageID()
 
         feature_dict = FeatureDict(
             features=features_dict,
             time_key="t",
             position_key="pos",
-            tracklet_key="track_id" if is_solution else None,
+            tracklet_key="tracklet_id" if is_solution else None,
             lineage_key="lineage_id" if is_solution else None,
         )
 
@@ -437,7 +437,7 @@ def graph_2d_list(tmp_path) -> td.graph.GraphView:
             "x": 50,
             "t": 0,
             "area": 1245,
-            "track_id": 1,
+            "tracklet_id": 1,
             "lineage_id": 1,
         },
         {
@@ -445,14 +445,14 @@ def graph_2d_list(tmp_path) -> td.graph.GraphView:
             "x": 100,
             "t": 1,
             "area": 500,
-            "track_id": 2,
+            "tracklet_id": 2,
             "lineage_id": 2,
         },
     ]
     graph.add_node_attr_key("y", default_value=0.0, dtype=pl.Float64)
     graph.add_node_attr_key("x", default_value=0.0, dtype=pl.Float64)
     graph.add_node_attr_key("area", default_value=0.0, dtype=pl.Float64)
-    graph.add_node_attr_key("track_id", default_value=0.0, dtype=pl.Float64)
+    graph.add_node_attr_key("tracklet_id", default_value=0.0, dtype=pl.Float64)
     graph.add_node_attr_key("lineage_id", default_value=0.0, dtype=pl.Float64)
 
     graph.bulk_add_nodes(nodes=nodes, indices=[1, 2])

--- a/tests/data_model/test_solution_tracks.py
+++ b/tests/data_model/test_solution_tracks.py
@@ -10,7 +10,7 @@ from funtracks.utils.tracksdata_utils import (
     td_mask_to_pixels,
 )
 
-track_attrs = {"time_attr": "t", "tracklet_attr": "track_id"}
+track_attrs = {"time_attr": "t", "tracklet_attr": "tracklet_id"}
 
 
 def test_recompute_track_ids(graph_2d_with_track_id):
@@ -28,7 +28,7 @@ def test_next_track_id(graph_2d_with_track_id):
     AddNode(
         tracks,
         node=10,
-        attributes={"t": 3, "pos": [0, 0], "track_id": 10},
+        attributes={"t": 3, "pos": [0, 0], "tracklet_id": 10},
     )
     assert tracks.get_next_track_id() == 11
 
@@ -91,7 +91,7 @@ def test_update_segmentation(graph_2d_with_segmentation):
 
 def test_next_track_id_empty():
     graph = create_empty_graphview_graph(
-        node_attributes=["pos", "track_id"],
+        node_attributes=["pos", "tracklet_id"],
         edge_attributes=[],
     )
     tracks = SolutionTracks(graph, ndim=4, **track_attrs)
@@ -102,7 +102,7 @@ def test_get_lineage_id_without_lineage_key(graph_2d_with_track_id):
     """Test that get_lineage_id returns None when lineage_key is not set."""
     graph = graph_2d_with_track_id
     graph.add_node(
-        attrs={"t": 1, "pos": [0, 0], "track_id": 1}, index=7, validate_keys=False
+        attrs={"t": 1, "pos": [0, 0], "tracklet_id": 1}, index=7, validate_keys=False
     )
     tracks = SolutionTracks(graph, ndim=3, **track_attrs)
 

--- a/tests/data_model/test_tracks.py
+++ b/tests/data_model/test_tracks.py
@@ -127,10 +127,10 @@ def test_get_set_node_attr(graph_2d_with_segmentation):
 
     tracks._set_node_attr(1, "area", 42)
 
-    tracks._set_nodes_attr([1, 2], "track_id", [7, 8])
+    tracks._set_nodes_attr([1, 2], "tracklet_id", [7, 8])
     assert tracks.get_node_attr(1, "area") == 42
-    assert tracks.get_nodes_attr([1, 2], "track_id") == [7, 8]
-    assert tracks.get_nodes_attr([1, 2], "track_id") == [7, 8]
+    assert tracks.get_nodes_attr([1, 2], "tracklet_id") == [7, 8]
+    assert tracks.get_nodes_attr([1, 2], "tracklet_id") == [7, 8]
     with pytest.raises(KeyError):
         tracks.get_node_attr(1, "not_present")
     with pytest.raises(KeyError):

--- a/tests/import_export/test_csv_export.py
+++ b/tests/import_export/test_csv_export.py
@@ -8,8 +8,8 @@ from funtracks.import_export import export_to_csv
 @pytest.mark.parametrize(
     ("ndim", "expected_header"),
     [
-        (3, ["t", "y", "x", "id", "parent_id", "track_id"]),
-        (4, ["t", "z", "y", "x", "id", "parent_id", "track_id"]),
+        (3, ["t", "y", "x", "id", "parent_id", "tracklet_id"]),
+        (4, ["t", "z", "y", "x", "id", "parent_id", "tracklet_id"]),
     ],
     ids=["2d", "3d"],
 )
@@ -36,8 +36,8 @@ def test_export_solution_to_csv(get_tracks, tmp_path, ndim, expected_header):
 @pytest.mark.parametrize(
     ("ndim", "expected_header"),
     [
-        (3, ["t", "y", "x", "id", "parent_id", "track_id"]),
-        (4, ["t", "z", "y", "x", "id", "parent_id", "track_id"]),
+        (3, ["t", "y", "x", "id", "parent_id", "tracklet_id"]),
+        (4, ["t", "z", "y", "x", "id", "parent_id", "tracklet_id"]),
     ],
     ids=["2d", "3d"],
 )
@@ -61,10 +61,12 @@ def test_export_solution_to_csv_with_seg_zarr(
     assert isinstance(seg_zarr, zarr.Array)
     assert seg_zarr.shape == tracks.segmentation.shape
 
-    # values should be track_ids (not node_ids) — default seg_label_attr="track_id"
+    # values should be track_ids (not node_ids) — default seg_label_attr="tracklet_id"
     seg_arr = seg_zarr[:]
     unique_vals = set(seg_arr.flatten()) - {0}
-    track_ids = set(tracks.graph.node_attrs(attr_keys=["track_id"])["track_id"].to_list())
+    track_ids = set(
+        tracks.graph.node_attrs(attr_keys=["tracklet_id"])["tracklet_id"].to_list()
+    )
     assert unique_vals == track_ids
 
 
@@ -86,9 +88,11 @@ def test_export_solution_to_csv_with_seg_tiff(get_tracks, tmp_path, ndim):
     seg_arr = tifffile.imread(str(seg_file))
     assert seg_arr.shape == tracks.segmentation.shape
 
-    # values should be track_ids (not node_ids) — default seg_label_attr="track_id"
+    # values should be track_ids (not node_ids) — default seg_label_attr="tracklet_id"
     unique_vals = set(seg_arr.flatten()) - {0}
-    track_ids = set(tracks.graph.node_attrs(attr_keys=["track_id"])["track_id"].to_list())
+    track_ids = set(
+        tracks.graph.node_attrs(attr_keys=["tracklet_id"])["tracklet_id"].to_list()
+    )
     assert unique_vals == track_ids
 
 

--- a/tests/import_export/test_csv_import.py
+++ b/tests/import_export/test_csv_import.py
@@ -711,3 +711,66 @@ class TestSpatialDimsValidation:
 
         with pytest.raises(ValueError, match="pos.*mapping.*segmentation"):
             tracks_from_df(df, node_name_map=name_map)
+
+
+class TestTrackletIdImport:
+    """Regression tests for user-provided tracklet IDs must
+    survive import unchanged regardless of which spelling (the public
+    DEFAULT_TRACKLET_KEY or the legacy "track_id") is used in name_map.
+    """
+
+    @staticmethod
+    def _df_with_two_tracks() -> pd.DataFrame:
+        # Two disjoint linear tracks with deliberately non-sequential tracklet
+        # IDs (42, 99) so that a fresh recompute via weakly_connected_components
+        # would yield (1, 2) and the assertion catches the silent overwrite.
+        return pd.DataFrame(
+            {
+                "ID": [1, 2, 3, 10, 11, 12],
+                "Time": [0, 1, 2, 0, 1, 2],
+                "y": [10.0, 11.0, 12.0, 50.0, 51.0, 52.0],
+                "x": [10.0, 11.0, 12.0, 50.0, 51.0, 52.0],
+                "Parent ID": [-1, 1, 2, -1, 10, 11],
+                "Tracklet ID": [42, 42, 42, 99, 99, 99],
+            }
+        )
+
+    def test_preserves_tracklet_ids_with_default_key(self):
+        """name_map using DEFAULT_TRACKLET_KEY ('tracklet_id') must preserve IDs."""
+        from funtracks.annotators._track_annotator import DEFAULT_TRACKLET_KEY
+
+        df = self._df_with_two_tracks()
+        name_map = {
+            "id": "ID",
+            "time": "Time",
+            "pos": ["y", "x"],
+            "parent_id": "Parent ID",
+            DEFAULT_TRACKLET_KEY: "Tracklet ID",
+        }
+        tracks = tracks_from_df(df, node_name_map=name_map)
+
+        expected = dict(zip(df["ID"], df["Tracklet ID"], strict=True))
+        for nid in df["ID"]:
+            assert tracks.get_track_id(nid) == expected[nid], (
+                f"node {nid}: expected tracklet {expected[nid]}, "
+                f"got {tracks.get_track_id(nid)} (silent recompute?)"
+            )
+
+    def test_preserves_tracklet_ids_with_legacy_key(self):
+        """name_map using legacy 'track_id' must continue to preserve IDs."""
+        df = self._df_with_two_tracks()
+        name_map = {
+            "id": "ID",
+            "time": "Time",
+            "pos": ["y", "x"],
+            "parent_id": "Parent ID",
+            "track_id": "Tracklet ID",
+        }
+        tracks = tracks_from_df(df, node_name_map=name_map)
+
+        expected = dict(zip(df["ID"], df["Tracklet ID"], strict=True))
+        for nid in df["ID"]:
+            assert tracks.get_track_id(nid) == expected[nid], (
+                f"node {nid}: expected tracklet {expected[nid]}, "
+                f"got {tracks.get_track_id(nid)}"
+            )

--- a/tests/import_export/test_export_to_geff.py
+++ b/tests/import_export/test_export_to_geff.py
@@ -11,7 +11,7 @@ from funtracks.import_export import export_to_geff
 @pytest.mark.parametrize("ndim", [3, 4])
 @pytest.mark.parametrize("with_seg", [True, False])
 @pytest.mark.parametrize("save_segmentation", [True, False])
-@pytest.mark.parametrize("seg_label_attr", ["track_id", None])
+@pytest.mark.parametrize("seg_label_attr", ["tracklet_id", None])
 @pytest.mark.parametrize("is_solution", [True, False])
 @pytest.mark.parametrize("pos_attr_type", (str, list))
 def test_export_to_geff(
@@ -56,7 +56,7 @@ def test_export_to_geff(
             graph,
             time_attr="t",
             pos_attr=pos_keys,
-            tracklet_attr="track_id" if is_solution else None,
+            tracklet_attr="tracklet_id" if is_solution else None,
             ndim=ndim,
         )
     else:
@@ -68,7 +68,7 @@ def test_export_to_geff(
     if (
         with_seg
         and save_segmentation
-        and seg_label_attr == "track_id"
+        and seg_label_attr == "tracklet_id"
         and not is_solution
     ):
         export_dir = tmp_path / "export"
@@ -219,9 +219,11 @@ def test_export_to_geff_seg_tiff(get_tracks, ndim, tmp_path):
     seg_arr = tifffile.imread(str(tmp_path / "segmentation.tif"))
     assert seg_arr.shape == tracks.segmentation.shape
 
-    # values should be track_ids (default seg_label_attr="track_id")
+    # values should be track_ids (default seg_label_attr="tracklet_id")
     unique_vals = set(seg_arr.flatten()) - {0}
-    track_ids = set(tracks.graph.node_attrs(attr_keys=["track_id"])["track_id"].to_list())
+    track_ids = set(
+        tracks.graph.node_attrs(attr_keys=["tracklet_id"])["tracklet_id"].to_list()
+    )
     assert unique_vals == track_ids
 
     # Check metadata references the tiff path with ../../ prefix (sibling of geff dir)

--- a/tests/import_export/test_import_from_geff.py
+++ b/tests/import_export/test_import_from_geff.py
@@ -918,20 +918,20 @@ def test_embedded_seg_ellipse_axis_radii_feature_metadata(tmp_path):
         "pos",
         "area",
         "ellipse_axis_radii",
-        "track_id",
+        "tracklet_id",
         "lineage_id",
         td.DEFAULT_ATTR_KEYS.MASK,
         td.DEFAULT_ATTR_KEYS.BBOX,
     ]
     # node_default_values must align with node_attributes by index.
-    # pos/track_id/mask/bbox are handled by special cases in create_empty_graphview_graph
-    # and their slot values here are never accessed; only area, ellipse_axis_radii,
-    # and lineage_id go through the general loop.
+    # pos/tracklet_id/mask/bbox are handled by special cases in
+    # create_empty_graphview_graph and their slot values here are never accessed;
+    # only area, ellipse_axis_radii, and lineage_id go through the general loop.
     node_default_values = [
         None,  # pos — special-cased, slot unused
         0.0,  # area
         np.array([0.0, 0.0]),  # ellipse_axis_radii — must be Array(Float64, 2)
-        None,  # track_id — special-cased, slot unused
+        None,  # tracklet_id — special-cased, slot unused
         -1,  # lineage_id
         None,  # mask — special-cased, slot unused
         None,  # bbox — special-cased, slot unused
@@ -950,7 +950,7 @@ def test_embedded_seg_ellipse_axis_radii_feature_metadata(tmp_path):
                 "pos": np.array([35.0, 40.0]),
                 "area": 900.0,
                 "ellipse_axis_radii": np.array([20.0, 15.0]),
-                "track_id": 1,
+                "tracklet_id": 1,
                 "lineage_id": 1,
                 "solution": 1,
                 td.DEFAULT_ATTR_KEYS.MASK: _make_mask(bbox),

--- a/tests/import_export/test_import_from_geff.py
+++ b/tests/import_export/test_import_from_geff.py
@@ -475,7 +475,7 @@ def test_import_from_geff_roundtrip_auto_axes(tmp_path):
         node_attributes=[
             "pos",
             "area",
-            "track_id",
+            "tracklet_id",
             "lineage_id",
             td.DEFAULT_ATTR_KEYS.MASK,
             td.DEFAULT_ATTR_KEYS.BBOX,
@@ -490,7 +490,7 @@ def test_import_from_geff_roundtrip_auto_axes(tmp_path):
                 "t": 0,
                 "pos": np.array([50.0, 50.0]),
                 "area": 1681.0,
-                "track_id": 1,
+                "tracklet_id": 1,
                 "lineage_id": 1,
                 "solution": 1,
                 td.DEFAULT_ATTR_KEYS.MASK: _make_mask(bbox),
@@ -783,3 +783,118 @@ def test_3d_pos_survives_sql_roundtrip(tmp_path):
         "This likely means construct_graph() used the wrong ndim when registering "
         "the pos schema, causing a mismatch with the actual 3-element data."
     )
+
+
+class TestGeffTrackletIdImport:
+    """Regression tests on the GEFF import path: a user's tracklet IDs must
+    survive import unchanged regardless of which spelling — the public
+    DEFAULT_TRACKLET_KEY or the legacy "track_id" — is used in node_name_map.
+    """
+
+    @staticmethod
+    def _legacy_geff_store():
+        """Build a GEFF store with the tracklet column under the pre-2.0
+        'track_id' property name and deliberately non-sequential tracklet IDs
+        so any recompute over weakly-connected components yields different
+        values and the assertion catches the silent overwrite.
+
+        The first two edges from create_mock_geff connect nodes {0,1,2} into
+        a chain (so they form a valid connected tracklet); the remaining nodes
+        are isolated singletons each with their own tracklet ID.
+
+        Returns (store, expected_id_map).
+        """
+        track_id_values = np.array([42, 42, 42, 99, 100, 101])
+        store, memory_geff = create_mock_geff(
+            node_id_dtype="uint",
+            node_axis_dtypes={"position": "float64", "time": "int64"},
+            directed=True,
+            num_nodes=6,
+            num_edges=2,
+            include_t=True,
+            include_z=False,
+            include_y=True,
+            include_x=True,
+            extra_node_props={"track_id": track_id_values},
+        )
+        node_ids = memory_geff["node_ids"]
+        expected = {
+            int(nid): int(t) for nid, t in zip(node_ids, track_id_values, strict=True)
+        }
+        return store, expected
+
+    def test_geff_legacy_property_renamed_to_default_key(self):
+        """A GEFF with the legacy 'track_id' property loaded under the public
+        DEFAULT_TRACKLET_KEY (renaming via name_map) must preserve tracklet IDs.
+        """
+        from funtracks.annotators._track_annotator import DEFAULT_TRACKLET_KEY
+
+        store, expected = self._legacy_geff_store()
+
+        name_map = {
+            "time": "t",
+            "pos": ["y", "x"],
+            # Rename: load source property "track_id" under standard key "tracklet_id"
+            DEFAULT_TRACKLET_KEY: "track_id",
+        }
+        tracks_out = import_from_geff(store, name_map)
+
+        for nid, exp_id in expected.items():
+            assert tracks_out.get_track_id(nid) == exp_id, (
+                f"node {nid}: expected tracklet {exp_id}, "
+                f"got {tracks_out.get_track_id(nid)} (silent recompute?)"
+            )
+
+    def test_geff_legacy_property_with_legacy_key(self):
+        """A GEFF with the legacy 'track_id' property loaded under the legacy
+        spelling in name_map must also preserve tracklet IDs (covers the
+        legacy-fallback path in _setup_core_computed_features).
+        """
+        store, expected = self._legacy_geff_store()
+
+        name_map = {
+            "time": "t",
+            "pos": ["y", "x"],
+            "track_id": "track_id",  # legacy spelling on both sides
+        }
+        tracks_out = import_from_geff(store, name_map)
+
+        for nid, exp_id in expected.items():
+            assert tracks_out.get_track_id(nid) == exp_id, (
+                f"node {nid}: expected tracklet {exp_id}, "
+                f"got {tracks_out.get_track_id(nid)}"
+            )
+
+    def test_geff_canonical_property_preserves_tracklet_ids(self, get_tracks, tmp_path):
+        """End-to-end round-trip via export_to_geff (canonical property name).
+
+        Conftest's get_tracks builds a SolutionTracks with non-sequential
+        tracklet IDs ({1:1, 2:2, 3:3, 4:3, 5:3, 6:5} — note 5 skips 4), so a
+        fresh recompute over weakly-connected components would yield different
+        IDs and the assertion catches the regression.
+        """
+        from funtracks.annotators._track_annotator import DEFAULT_TRACKLET_KEY
+
+        tracks_in = get_tracks(ndim=3, with_seg=False, is_solution=True)
+        expected = {
+            int(nid): tracks_in.get_track_id(int(nid))
+            for nid in tracks_in.graph.node_ids()
+        }
+
+        export_dir = tmp_path / "export"
+        export_dir.mkdir()
+        export_to_geff(tracks_in, export_dir, save_segmentation=False)
+
+        name_map = {
+            "time": "t",
+            "pos": ["y", "x"],
+            DEFAULT_TRACKLET_KEY: DEFAULT_TRACKLET_KEY,
+            "lineage_id": "lineage_id",
+        }
+        tracks_out = import_from_geff(export_dir / "tracks.geff", name_map)
+
+        for nid, exp_id in expected.items():
+            assert tracks_out.get_track_id(nid) == exp_id, (
+                f"node {nid}: expected tracklet {exp_id}, "
+                f"got {tracks_out.get_track_id(nid)}"
+            )

--- a/tests/import_export/test_internal_format.py
+++ b/tests/import_export/test_internal_format.py
@@ -12,6 +12,18 @@ from funtracks.import_export._v1_format import (
 )
 
 
+def _normalize_tracklet_key(name: str) -> str:
+    """Map both spellings of the tracklet key to a single canonical name so a
+    pre-2.0 saved fixture (with 'track_id') can be compared to a freshly-built
+    tracks object (with 'tracklet_id') without spurious key mismatches.
+
+    The legacy fallback in _setup_core_computed_features intentionally keeps
+    the original 'track_id' spelling on saved-and-loaded data; that is the
+    behaviour this normalization papers over for the comparison only.
+    """
+    return "tracklet_id" if name == "track_id" else name
+
+
 @pytest.mark.parametrize("with_seg", [True, False])
 @pytest.mark.parametrize("ndim", [3, 4])
 @pytest.mark.parametrize("is_solution", [True, False])
@@ -33,11 +45,18 @@ def test_save_load(
     assert loaded.features.time_key == tracks.features.time_key
     assert loaded.features.position_key == tracks.features.position_key
 
-    # Check that features dictionaries have same keys
-    assert set(loaded.features.keys()) == set(tracks.features.keys())
+    # Check that features dictionaries describe the same set of features.
+    # Legacy fixtures store the tracklet column as 'track_id'; current code
+    # produces 'tracklet_id'. Normalise both sides to the canonical spelling.
+    loaded_keys = {_normalize_tracklet_key(k) for k in loaded.features}
+    tracks_keys = {_normalize_tracklet_key(k) for k in tracks.features}
+    assert loaded_keys == tracks_keys
 
-    # Check that each feature has matching values
+    # Check that each feature has matching values (skip tracklet feature: its
+    # key spelling differs on loaded legacy fixtures, see comment above)
     for key in tracks.features:
+        if key in {"tracklet_id", "track_id"}:
+            continue
         loaded_feature = loaded.features[key]
         tracks_feature = tracks.features[key]
 
@@ -72,8 +91,15 @@ def test_save_load(
     else:
         assert loaded.segmentation is None
 
-    # graphs_equal doesn't exist for TracksData, so we check properties
-    assert set(loaded.graph.node_attr_keys()) == set(tracks.graph.node_attr_keys())
+    # graphs_equal doesn't exist for TracksData, so we check properties.
+    # Same legacy-key normalisation applies to graph node attributes.
+    loaded_node_attrs = {
+        _normalize_tracklet_key(k) for k in loaded.graph.node_attr_keys()
+    }
+    tracks_node_attrs = {
+        _normalize_tracklet_key(k) for k in tracks.graph.node_attr_keys()
+    }
+    assert loaded_node_attrs == tracks_node_attrs
     assert set(loaded.graph.edge_attr_keys()) == set(tracks.graph.edge_attr_keys())
     assert loaded.graph.num_nodes() == tracks.graph.num_nodes()
     assert loaded.graph.num_edges() == tracks.graph.num_edges()

--- a/tests/user_actions/test_user_actions_force.py
+++ b/tests/user_actions/test_user_actions_force.py
@@ -10,7 +10,7 @@ def test_user_force_add_downstream(get_tracks):
     tracks = get_tracks(ndim=3, with_seg=False, is_solution=True)
 
     # upstream division, with force
-    attrs = {"t": 2, "track_id": 1, "pos": [3, 4]}
+    attrs = {"t": 2, "tracklet_id": 1, "pos": [3, 4]}
     UserAddNode(tracks, node=7, attributes=attrs, force=True)
     assert tracks.get_track_id(7) == 1
     assert [1, 2] not in tracks.graph.edge_list()
@@ -25,7 +25,7 @@ def test_user_force_add_upstream(get_tracks):
     tracks = get_tracks(ndim=3, with_seg=False, is_solution=True)
 
     # downstream parent division, with force
-    attrs = {"t": 0, "track_id": 3, "pos": [3, 4]}
+    attrs = {"t": 0, "tracklet_id": 3, "pos": [3, 4]}
     UserAddNode(tracks, node=7, attributes=attrs, force=True)
     assert tracks.get_track_id(7) == 3
     assert [1, 2] in tracks.graph.edge_list()  # still there
@@ -41,7 +41,7 @@ def test_auto_assign_new_track_id(get_tracks):
 
     # existing track id at current time --> allowed, with warning
     with pytest.warns(UserWarning, match="Starting a new track, because track id"):
-        attrs = {"t": 1, "track_id": 2, "pos": [3, 4]}  # combination exists already
+        attrs = {"t": 1, "tracklet_id": 2, "pos": [3, 4]}  # combination exists already
         UserAddNode(tracks, node=7, attributes=attrs)
 
         assert tracks.graph.has_node(7)

--- a/tests/user_actions/test_user_add_delete_node.py
+++ b/tests/user_actions/test_user_add_delete_node.py
@@ -12,12 +12,12 @@ class TestUserAddDeleteNode:
         tracks = get_tracks(ndim=ndim, with_seg=with_seg, is_solution=True)
         # duplicate node
         with pytest.raises(InvalidActionError, match="Node .* already exists"):
-            attrs = {"t": 5, "track_id": 1}
+            attrs = {"t": 5, "tracklet_id": 1}
             UserAddNode(tracks, node=1, attributes=attrs)
 
         # no time
         with pytest.raises(InvalidActionError, match="Cannot add node without time"):
-            attrs = {"track_id": 1}
+            attrs = {"tracklet_id": 1}
             UserAddNode(tracks, node=7, attributes=attrs)
 
         # no track_id
@@ -30,7 +30,7 @@ class TestUserAddDeleteNode:
             InvalidActionError,
             match="Cannot add node here - upstream division event detected",
         ):
-            attrs = {"t": 2, "track_id": 1}
+            attrs = {"t": 2, "tracklet_id": 1}
             UserAddNode(tracks, node=7, attributes=attrs)
 
     def test_user_add_node(self, get_tracks, ndim, with_seg):
@@ -41,7 +41,7 @@ class TestUserAddDeleteNode:
         time = 3
         position = [50, 50, 50] if ndim == 4 else [50, 50]
         attributes = {
-            "track_id": track_id,
+            "tracklet_id": track_id,
             "pos": position,
             "t": time,
         }

--- a/tests/user_actions/test_user_update_node_attrs.py
+++ b/tests/user_actions/test_user_update_node_attrs.py
@@ -78,7 +78,7 @@ class TestUserUpdateNodeAttrs:
         tracks = get_tracks(ndim=ndim, with_seg=with_seg, is_solution=True)
 
         with pytest.raises(ValueError, match="Cannot update attribute"):
-            UserUpdateNodeAttrs(tracks, node=1, attrs={"track_id": 999})
+            UserUpdateNodeAttrs(tracks, node=1, attrs={"tracklet_id": 999})
 
     def test_protected_area_attr(self, get_tracks, ndim, with_seg):
         """Test that area attribute (managed by annotator) cannot be updated."""


### PR DESCRIPTION
There was a severe inconsistency in the naming of the `TRACKLET_KEY` throughout the repo. This wasn't surfaced by the tests, because all conftest and pre-computed graphs had "track_id", and not any other name. This PR: 1) resolved the inconsistency, 2) updates all tests accordingly, 3) speeds up track_id calculation. Claude blurp: 


The codebase had two strings for the same concept:

- `DEFAULT_TRACKLET_KEY = "tracklet_id"` — the public name exported from `funtracks.annotators` (what downstream callers like motile_tracker import).
- `"track_id"` — hardcoded as the default in `Tracks.__init__`, plus as string literals in validation, exports, and the annotator registry.

When a caller passed `node_name_map={"tracklet_id": "...", ...}` (the documented public spelling), the builder loaded the column under graph attribute `"tracklet_id"` but then called `SolutionTracks(graph=...)` **without forwarding** `tracklet_attr=`. `Tracks.__init__` defaulted it to `"track_id"`, didn't find that on the graph, and silently recomputed tracklet IDs from `weakly_connected_components` under a fresh `"track_id"` column. The user's original data was orphaned; `tracks.features.tracklet_key` pointed at the recomputed values — same number of unique tracklets, different assignments.

The fix collapses both failures: one canonical default everywhere (`DEFAULT_TRACKLET_KEY`), the builder forwards the key actually present in `node_props` to `SolutionTracks(tracklet_attr=...)`, and a fallback in `_setup_core_computed_features` lets pre-2.0 saved data (still using the literal `"track_id"`) load without recompute.
