### PR TITLE
enforce python integers when setting self.node in actions

### DIFF
--- a/src/funtracks/actions/add_delete_node.py
+++ b/src/funtracks/actions/add_delete_node.py
@@ -44,7 +44,7 @@ class AddNode(BasicAction):
         """
         super().__init__(tracks)
         self.tracks: SolutionTracks  # Narrow type from base class
-        self.node = node
+        self.node = int(node)
 
         # Get keys from tracks features
         time_key = tracks.features.time_key
@@ -107,7 +107,7 @@ class DeleteNode(BasicAction):
     ):
         super().__init__(tracks)
         self.tracks: SolutionTracks  # Narrow type from base class
-        self.node = node
+        self.node = int(node)
 
         # Save all node feature values from the features dict
         self.attributes = {}

--- a/src/funtracks/actions/update_node_attrs.py
+++ b/src/funtracks/actions/update_node_attrs.py
@@ -40,7 +40,7 @@ class UpdateNodeAttrs(BasicAction):
         for attr in attrs:
             if attr in protected_attrs:
                 raise ValueError(f"Cannot update attribute {attr} manually")
-        self.node = node
+        self.node = int(node)
         self.prev_attrs = {attr: self.tracks.get_node_attr(node, attr) for attr in attrs}
         self.new_attrs = attrs
         self._apply()

--- a/src/funtracks/actions/update_segmentation.py
+++ b/src/funtracks/actions/update_segmentation.py
@@ -34,7 +34,7 @@ class UpdateNodeSeg(BasicAction):
                 (False) from this node. Defaults to True
         """
         super().__init__(tracks)
-        self.node = node
+        self.node = int(node)
         self.mask = mask
         self.added = added
         self._apply()


### PR DESCRIPTION
This is the minimal fix for https://github.com/funkelab/motile_tracker/issues/402