### PR TITLE
allow big tiff and compression when exporting seg to tiff

### DIFF
--- a/src/funtracks/import_export/_export_segmentation.py
+++ b/src/funtracks/import_export/_export_segmentation.py
@@ -98,5 +98,5 @@ def export_segmentation(
         with tifffile.TiffWriter(output_path, bigtiff=True) as tif:
             for t in range(shape[0]):
                 tif.write(
-                    get_frame(t).astype(tiff_dtype), compression="deflate"
+                    get_frame(t).astype(tiff_dtype), contiguous=True
                 )  # compression may prevent contiguous writing

--- a/src/funtracks/import_export/_export_segmentation.py
+++ b/src/funtracks/import_export/_export_segmentation.py
@@ -95,6 +95,8 @@ def export_segmentation(
     else:  # tiff
         # Cast to int32 for broad compatibility (e.g. Fiji does not display int64)
         tiff_dtype = np.int32
-        with tifffile.TiffWriter(output_path, bigtiff=False) as tif:
+        with tifffile.TiffWriter(output_path, bigtiff=True) as tif:
             for t in range(shape[0]):
-                tif.write(get_frame(t).astype(tiff_dtype), contiguous=True)
+                tif.write(
+                    get_frame(t).astype(tiff_dtype), compression="deflate"
+                )  # compression may prevent contiguous writing


### PR DESCRIPTION
This would fix https://github.com/funkelab/motile_tracker/issues/413
I could not find a solution that combines streaming + big tiff + compression, so right now it is without compression (deflate).