### PR TITLE
Register mask/bbox as Features, simplify DeleteNode

### DIFF
--- a/src/funtracks/actions/add_delete_node.py
+++ b/src/funtracks/actions/add_delete_node.py
@@ -101,7 +101,7 @@ class DeleteNode(BasicAction):
         self.node = int(node)
 
         # Save all node feature values from the features dict
-        # (mask, bbox, and solution are now registered as Features, so they're
+        # (mask and bbox are now registered as Features, so they're
         # captured here automatically)
         self.attributes: dict[str, Any] = {}
         for key in self.tracks.features.node_features:

--- a/src/funtracks/actions/add_delete_node.py
+++ b/src/funtracks/actions/add_delete_node.py
@@ -101,7 +101,7 @@ class DeleteNode(BasicAction):
         self.node = int(node)
 
         # Save all node feature values from the features dict
-        # (mask and bbox are now registered as Features, so they're
+        # (mask, bbox, and solution are now registered as Features, so they're
         # captured here automatically)
         self.attributes: dict[str, Any] = {}
         for key in self.tracks.features.node_features:

--- a/src/funtracks/actions/add_delete_node.py
+++ b/src/funtracks/actions/add_delete_node.py
@@ -110,17 +110,13 @@ class DeleteNode(BasicAction):
         self.node = int(node)
 
         # Save all node feature values from the features dict
-        # (mask and solution are now registered as Features, so they're
+        # (mask, bbox, and solution are now registered as Features, so they're
         # captured here automatically)
         self.attributes = {}
-        for key, feature in self.tracks.features.node_features.items():
+        for key in self.tracks.features.node_features:
             val = self.tracks.get_node_attr(node, key)
             if val is not None:
                 self.attributes[key] = val
-            # For mask features, also save the paired bbox
-            if feature.get("value_type") == "mask":
-                bbox_key = feature["bbox_key"]
-                self.attributes[bbox_key] = self.tracks.get_node_attr(node, bbox_key)
 
         mask = self.tracks.get_mask(node) if mask is None else mask
 

--- a/src/funtracks/actions/add_delete_node.py
+++ b/src/funtracks/actions/add_delete_node.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import tracksdata as td
+
 from ._base import BasicAction
 
 if TYPE_CHECKING:
@@ -10,16 +12,12 @@ if TYPE_CHECKING:
     from funtracks.data_model.solution_tracks import SolutionTracks
     from funtracks.data_model.tracks import Node
 
-import tracksdata as td
-from tracksdata.nodes import Mask
-
 
 class AddNode(BasicAction):
-    """Action for adding new nodes. If a segmentation should also be added, the
-    mask for the node should be provided. The label to set the mask will
-    be taken from the node id. The existing pixel values are assumed to be
-    zero - you must explicitly update any other segmentations that were overwritten
-    using an UpdateNodes action if you want to be able to undo the action.
+    """Action for adding new nodes.
+
+    All node attributes (including mask and bbox if applicable) should be
+    provided in the ``attributes`` dict.
     """
 
     def __init__(
@@ -27,20 +25,19 @@ class AddNode(BasicAction):
         tracks: SolutionTracks,
         node: Node,
         attributes: dict[str, Any],
-        mask: Mask | None = None,
     ):
-        """Create an action to add a new node, with optional segmentation
+        """Create an action to add a new node.
 
         Args:
-            tracks (Tracks): The Tracks to add the node to
-            node (Node): A node id
-            attributes (Attrs): Includes times, track_ids, and optionally positions
-            mask (Mask | None, optional): The segmentation mask associated with
-                the node. Defaults to None.
+            tracks: The Tracks to add the node to.
+            node: A node id.
+            attributes: Node attributes including time, track_id, and
+                optionally position, mask, bbox, etc.
+
         Raises:
             ValueError: If time attribute is not in attributes.
             ValueError: If track_id is not in attributes.
-            ValueError: If mask is None and position is not in attributes.
+            ValueError: If neither position nor a mask feature is in attributes.
         """
         super().__init__(tracks)
         self.tracks: SolutionTracks  # Narrow type from base class
@@ -57,21 +54,20 @@ class AddNode(BasicAction):
         if track_id_key not in attributes:
             raise ValueError(f"Must provide a {track_id_key} attribute for node {node}")
 
-        # Check for position - handle both single key and list of keys
-        if mask is None:
+        # Check for position — not needed if the default mask is in attributes
+        # (position will be computed from the mask by annotators)
+        if td.DEFAULT_ATTR_KEYS.MASK not in attributes:
             if isinstance(pos_key, list):
-                # Multi-axis position keys
                 if not all(key in attributes for key in pos_key):
                     raise ValueError(
                         f"Must provide position or segmentation for node {node}"
                     )
             else:
-                # Single position key
                 if pos_key not in attributes:
                     raise ValueError(
                         f"Must provide position or segmentation for node {node}"
                     )
-        self.mask = mask
+
         self.attributes = attributes
         self._apply()
 
@@ -80,30 +76,25 @@ class AddNode(BasicAction):
         return DeleteNode(self.tracks, self.node)
 
     def _apply(self) -> None:
-        """Apply the action, and set segmentation if provided in self.mask"""
-        attrs = dict(self.attributes)
-
-        if self.tracks.segmentation is not None and self.mask is not None:
-            attrs[td.DEFAULT_ATTR_KEYS.MASK] = self.mask
-            attrs[td.DEFAULT_ATTR_KEYS.BBOX] = self.mask.bbox
-
-        self.tracks.graph.add_node(attrs=attrs, index=self.node, validate_keys=False)
+        """Add the node with all attributes from self.attributes."""
+        self.tracks.graph.add_node(
+            attrs=dict(self.attributes), index=self.node, validate_keys=False
+        )
 
         # Always notify annotators - they will check their own preconditions
         self.tracks.notify_annotators(self)
 
 
 class DeleteNode(BasicAction):
-    """Action of deleting existing node
-    If the tracks contain a segmentation, this action also constructs a reversible
-    operation for setting involved masks to zero
+    """Action of deleting an existing node.
+
+    Saves all node feature values so the action can be inverted.
     """
 
     def __init__(
         self,
         tracks: SolutionTracks,
         node: Node,
-        mask: Mask | None = None,
     ):
         super().__init__(tracks)
         self.tracks: SolutionTracks  # Narrow type from base class
@@ -112,28 +103,19 @@ class DeleteNode(BasicAction):
         # Save all node feature values from the features dict
         # (mask, bbox, and solution are now registered as Features, so they're
         # captured here automatically)
-        self.attributes = {}
+        self.attributes: dict[str, Any] = {}
         for key in self.tracks.features.node_features:
             val = self.tracks.get_node_attr(node, key)
             if val is not None:
                 self.attributes[key] = val
 
-        mask = self.tracks.get_mask(node) if mask is None else mask
-
-        self.mask = mask
         self._apply()
 
     def inverse(self) -> BasicAction:
-        """Invert this action, and provide inverse segmentation operation if given"""
-
-        return AddNode(self.tracks, self.node, self.attributes, mask=self.mask)
+        """Invert this action to re-add the node with its saved attributes."""
+        return AddNode(self.tracks, self.node, self.attributes)
 
     def _apply(self) -> None:
-        """ASSUMES THERE ARE NO INCIDENT EDGES - raises valueerror if an edge will be
-        removed by this operation
-        Steps:
-        - Remove nodes from graph
-        - Update annotators
-        """
+        """Remove the node from the graph."""
         self.tracks.graph.remove_node(self.node)
         self.tracks.notify_annotators(self)

--- a/src/funtracks/actions/add_delete_node.py
+++ b/src/funtracks/actions/add_delete_node.py
@@ -110,22 +110,17 @@ class DeleteNode(BasicAction):
         self.node = int(node)
 
         # Save all node feature values from the features dict
+        # (mask and solution are now registered as Features, so they're
+        # captured here automatically)
         self.attributes = {}
-        for key in self.tracks.features.node_features:
+        for key, feature in self.tracks.features.node_features.items():
             val = self.tracks.get_node_attr(node, key)
             if val is not None:
                 self.attributes[key] = val
-
-        if td.DEFAULT_ATTR_KEYS.MASK in self.tracks.graph.node_attr_keys():
-            self.attributes[td.DEFAULT_ATTR_KEYS.MASK] = self.tracks.get_nodes_attr(
-                [self.node], td.DEFAULT_ATTR_KEYS.MASK
-            )[0]
-            self.attributes[td.DEFAULT_ATTR_KEYS.BBOX] = self.tracks.get_nodes_attr(
-                [self.node], td.DEFAULT_ATTR_KEYS.BBOX
-            )[0]
-        self.attributes[td.DEFAULT_ATTR_KEYS.SOLUTION] = self.tracks.get_nodes_attr(
-            [self.node], td.DEFAULT_ATTR_KEYS.SOLUTION
-        )[0]
+            # For mask features, also save the paired bbox
+            if feature.get("value_type") == "mask":
+                bbox_key = feature["bbox_key"]
+                self.attributes[bbox_key] = self.tracks.get_node_attr(node, bbox_key)
 
         mask = self.tracks.get_mask(node) if mask is None else mask
 

--- a/src/funtracks/actions/update_segmentation.py
+++ b/src/funtracks/actions/update_segmentation.py
@@ -24,6 +24,7 @@ class UpdateNodeSeg(BasicAction):
         node: Node,
         mask: Mask,
         added: bool = True,
+        mask_key: str = td.DEFAULT_ATTR_KEYS.MASK,
     ):
         """
         Args:
@@ -32,11 +33,14 @@ class UpdateNodeSeg(BasicAction):
             mask (Mask): The mask that was updated for the node
             added (bool, optional): If the provided mask were added (True) or deleted
                 (False) from this node. Defaults to True
+            mask_key: The feature key for the mask column.
+                Defaults to the standard mask key.
         """
         super().__init__(tracks)
         self.node = int(node)
         self.mask = mask
         self.added = added
+        self.mask_key = mask_key
         self._apply()
 
     def inverse(self) -> BasicAction:
@@ -46,6 +50,7 @@ class UpdateNodeSeg(BasicAction):
             self.node,
             mask=self.mask,
             added=not self.added,
+            mask_key=self.mask_key,
         )
 
     def _apply(self) -> None:
@@ -56,26 +61,14 @@ class UpdateNodeSeg(BasicAction):
 
         if value == 0:
             # val=0 means deleting (part of) the mask
-            mask_old = self.tracks.graph.nodes[self.node][td.DEFAULT_ATTR_KEYS.MASK]
+            mask_old = self.tracks.graph.nodes[self.node][self.mask_key]
             mask_subtracted = mask_old.__isub__(mask_new)
-            self.tracks.graph.update_node_attrs(
-                attrs={
-                    td.DEFAULT_ATTR_KEYS.MASK: [mask_subtracted],
-                    td.DEFAULT_ATTR_KEYS.BBOX: [mask_subtracted.bbox],
-                },
-                node_ids=[self.node],
-            )
+            self.tracks.update_mask(self.node, mask_subtracted, mask_key=self.mask_key)
 
         elif self.tracks.graph.has_node(value):
             # if node already exists:
-            mask_old = self.tracks.graph.nodes[value][td.DEFAULT_ATTR_KEYS.MASK]
+            mask_old = self.tracks.graph.nodes[value][self.mask_key]
             mask_combined = mask_old.__or__(mask_new)
-            self.tracks.graph.update_node_attrs(
-                attrs={
-                    td.DEFAULT_ATTR_KEYS.MASK: [mask_combined],
-                    td.DEFAULT_ATTR_KEYS.BBOX: [mask_combined.bbox],
-                },
-                node_ids=[value],
-            )
+            self.tracks.update_mask(value, mask_combined, mask_key=self.mask_key)
 
         self.tracks.notify_annotators(self)

--- a/src/funtracks/data_model/tracks.py
+++ b/src/funtracks/data_model/tracks.py
@@ -516,15 +516,15 @@ class Tracks:
         """
         return int(self.get_node_attr(node, self.features.time_key))
 
-    def get_mask(self, node: Node) -> Mask | None:
+    def get_mask(
+        self, node: Node, mask_key: str = td.DEFAULT_ATTR_KEYS.MASK
+    ) -> Mask | None:
         """Get the segmentation mask associated with a given node.
 
-        .. deprecated:: 1.0
-            `set_time` will be removed in funtracks v2.0.
-            Use `update_node_attrs([node], {tracks.features.time_key: [time]})` instead.
-
         Args:
-            node (Node): The node to get the mask for.
+            node: The node to get the mask for.
+            mask_key: The feature key for the mask column.
+                Defaults to the standard mask key.
 
         Returns:
             Mask | None: The segmentation mask for the node, or None if no
@@ -533,8 +533,28 @@ class Tracks:
         if self.segmentation is None:
             return None
 
-        mask = self.graph.nodes[node][td.DEFAULT_ATTR_KEYS.MASK]
+        mask = self.graph.nodes[node][mask_key]
         return mask
+
+    def update_mask(
+        self, node: Node, mask: Mask, mask_key: str = td.DEFAULT_ATTR_KEYS.MASK
+    ) -> None:
+        """Update the segmentation mask for an existing node, auto-syncing the bbox.
+
+        Writes both the mask and its bbox to the graph. The bbox key is
+        looked up from the mask Feature's derived_features list.
+
+        Args:
+            node: The node to update the mask for.
+            mask: The Mask object (carries .bbox).
+            mask_key: The feature key for the mask column.
+                Defaults to the standard mask key.
+        """
+        self.graph.nodes[node][mask_key] = mask
+        mask_feature = self.features.get(mask_key)
+        if mask_feature is not None:
+            for derived_key in mask_feature.get("derived_features", []):
+                self.graph.nodes[node][derived_key] = mask.bbox
 
     def undo(self) -> bool:
         """Undo the last performed action from the action history.

--- a/src/funtracks/data_model/tracks.py
+++ b/src/funtracks/data_model/tracks.py
@@ -553,6 +553,8 @@ class Tracks:
         self.graph.nodes[node][mask_key] = mask
         mask_feature = self.features.get(mask_key)
         if mask_feature is not None:
+            # NOTE: all derived features of a mask are currently assumed to be
+            # its bounding box. Revisit if non-bbox derived features are added.
             for derived_key in mask_feature.get("derived_features", []):
                 self.graph.nodes[node][derived_key] = mask.bbox
 
@@ -737,19 +739,16 @@ class Tracks:
 
         # Perform custom graph operations when a feature is added
         if feature["feature_type"] == "node" and key not in self.graph.node_attr_keys():
-            if feature["value_type"] == "mask":
-                # Mask features use pl.Object
-                self.graph.add_node_attr_key(key, default_value=None, dtype=pl.Object)
-            else:
-                dtype = to_polars_dtype(feature["value_type"])
-                num_values = feature.get("num_values")
-                if num_values is not None and num_values > 1:
-                    dtype = pl.Array(to_polars_dtype(feature["value_type"]), num_values)
-                self.graph.add_node_attr_key(
-                    key,
-                    default_value=feature["default_value"],
-                    dtype=dtype,
-                )
+            # "mask" value_type maps to pl.Object via to_polars_dtype
+            dtype = to_polars_dtype(feature["value_type"])
+            num_values = feature.get("num_values")
+            if num_values is not None and num_values > 1:
+                dtype = pl.Array(dtype, num_values)
+            self.graph.add_node_attr_key(
+                key,
+                default_value=feature["default_value"],
+                dtype=dtype,
+            )
         elif feature["feature_type"] == "edge" and key not in self.graph.edge_attr_keys():
             self.graph.add_edge_attr_key(
                 key,

--- a/src/funtracks/data_model/tracks.py
+++ b/src/funtracks/data_model/tracks.py
@@ -17,7 +17,7 @@ from tracksdata.array import GraphArrayView
 from tracksdata.nodes import Mask
 
 from funtracks.actions.action_history import ActionHistory
-from funtracks.features import Feature, FeatureDict, Position, Time
+from funtracks.features import Feature, FeatureDict, Position, SegMask, Solution, Time
 from funtracks.utils.tracksdata_utils import (
     to_polars_dtype,
 )
@@ -33,7 +33,6 @@ Node: TypeAlias = int
 Edge: TypeAlias = tuple[Node, Node]
 AttrValues: TypeAlias = list[AttrValue]
 Attrs: TypeAlias = dict[str, AttrValues]
-SegMask: TypeAlias = tuple[np.ndarray, ...]
 
 logger = logging.getLogger(__name__)
 
@@ -237,6 +236,16 @@ class Tracks:
             pos_feature = Position(axes=self.axis_names)
             feature_dict.register_position_feature(single_position_key, pos_feature)
         # else: single pos_attr with segmentation - RegionpropsAnnotator will handle it
+
+        # Register mask feature if segmentation exists
+        if self.segmentation is not None:
+            feature_dict[td.DEFAULT_ATTR_KEYS.MASK] = SegMask(
+                bbox_key=td.DEFAULT_ATTR_KEYS.BBOX
+            )
+
+        # Register solution if it's on the graph
+        if td.DEFAULT_ATTR_KEYS.SOLUTION in self.graph.node_attr_keys():
+            feature_dict[td.DEFAULT_ATTR_KEYS.SOLUTION] = Solution()
 
         return feature_dict
 
@@ -711,15 +720,26 @@ class Tracks:
 
         # Perform custom graph operations when a feature is added
         if feature["feature_type"] == "node" and key not in self.graph.node_attr_keys():
-            dtype = to_polars_dtype(feature["value_type"])
-            num_values = feature.get("num_values")
-            if num_values is not None and num_values > 1:
-                dtype = pl.Array(pl.Float64, num_values)
-            self.graph.add_node_attr_key(
-                key,
-                default_value=feature["default_value"],
-                dtype=dtype,
-            )
+            if feature["value_type"] == "mask":
+                # Mask features use pl.Object; also register the paired bbox column
+                self.graph.add_node_attr_key(key, default_value=None, dtype=pl.Object)
+                bbox_key = feature["bbox_key"]
+                if bbox_key not in self.graph.node_attr_keys():
+                    spatial_ndim = self.ndim - 1
+                    self.graph.add_node_attr_key(
+                        bbox_key,
+                        dtype=pl.Array(pl.Int64, 2 * spatial_ndim),
+                    )
+            else:
+                dtype = to_polars_dtype(feature["value_type"])
+                num_values = feature.get("num_values")
+                if num_values is not None and num_values > 1:
+                    dtype = pl.Array(pl.Float64, num_values)
+                self.graph.add_node_attr_key(
+                    key,
+                    default_value=feature["default_value"],
+                    dtype=dtype,
+                )
         elif feature["feature_type"] == "edge" and key not in self.graph.edge_attr_keys():
             self.graph.add_edge_attr_key(
                 key,
@@ -736,13 +756,27 @@ class Tracks:
         Args:
             key: The key for the feature to delete
         """
+        # Get feature metadata before removing from dict
+        feature = self.features.get(key)
+
         # Remove from the features dictionary
         del self.features[key]
 
+        # Determine feature_type from FeatureDict entry or annotators
+        if feature is not None:
+            feature_type = feature["feature_type"]
+        elif ann_entry := self.annotators.all_features.get(key):
+            feature_type = ann_entry[0]["feature_type"]
+        else:
+            return
+
         # Perform custom graph operations when a feature is deleted
-        if feature := self.annotators.all_features.get(key):
-            feature_type = feature[0]["feature_type"]
-            if feature_type == "node" and key in self.graph.node_attr_keys():
-                self.graph.remove_node_attr_key(key)
-            elif feature_type == "edge" and key in self.graph.edge_attr_keys():
-                self.graph.remove_edge_attr_key(key)
+        if feature_type == "node" and key in self.graph.node_attr_keys():
+            self.graph.remove_node_attr_key(key)
+            # For mask features, also remove the paired bbox column
+            if feature is not None and feature.get("value_type") == "mask":
+                bbox_key = feature.get("bbox_key")
+                if bbox_key and bbox_key in self.graph.node_attr_keys():
+                    self.graph.remove_node_attr_key(bbox_key)
+        elif feature_type == "edge" and key in self.graph.edge_attr_keys():
+            self.graph.remove_edge_attr_key(key)

--- a/src/funtracks/data_model/tracks.py
+++ b/src/funtracks/data_model/tracks.py
@@ -17,7 +17,7 @@ from tracksdata.array import GraphArrayView
 from tracksdata.nodes import Mask
 
 from funtracks.actions.action_history import ActionHistory
-from funtracks.features import Feature, FeatureDict, Position, SegMask, Solution, Time
+from funtracks.features import Feature, FeatureDict, Position, SegMask, Time
 from funtracks.utils.tracksdata_utils import (
     to_polars_dtype,
 )
@@ -242,10 +242,6 @@ class Tracks:
             feature_dict[td.DEFAULT_ATTR_KEYS.MASK] = SegMask(
                 bbox_key=td.DEFAULT_ATTR_KEYS.BBOX
             )
-
-        # Register solution if it's on the graph
-        if td.DEFAULT_ATTR_KEYS.SOLUTION in self.graph.node_attr_keys():
-            feature_dict[td.DEFAULT_ATTR_KEYS.SOLUTION] = Solution()
 
         return feature_dict
 

--- a/src/funtracks/data_model/tracks.py
+++ b/src/funtracks/data_model/tracks.py
@@ -17,7 +17,7 @@ from tracksdata.array import GraphArrayView
 from tracksdata.nodes import Mask
 
 from funtracks.actions.action_history import ActionHistory
-from funtracks.features import Feature, FeatureDict, Position, SegMask, Time
+from funtracks.features import Feature, FeatureDict, Position, SegBbox, SegMask, Time
 from funtracks.utils.tracksdata_utils import (
     to_polars_dtype,
 )
@@ -237,11 +237,12 @@ class Tracks:
             feature_dict.register_position_feature(single_position_key, pos_feature)
         # else: single pos_attr with segmentation - RegionpropsAnnotator will handle it
 
-        # Register mask feature if segmentation exists
+        # Register mask and bbox features if segmentation exists
         if self.segmentation is not None:
             feature_dict[td.DEFAULT_ATTR_KEYS.MASK] = SegMask(
-                bbox_key=td.DEFAULT_ATTR_KEYS.BBOX
+                self.ndim, bbox_key=td.DEFAULT_ATTR_KEYS.BBOX
             )
+            feature_dict[td.DEFAULT_ATTR_KEYS.BBOX] = SegBbox(self.ndim)
 
         return feature_dict
 
@@ -717,20 +718,13 @@ class Tracks:
         # Perform custom graph operations when a feature is added
         if feature["feature_type"] == "node" and key not in self.graph.node_attr_keys():
             if feature["value_type"] == "mask":
-                # Mask features use pl.Object; also register the paired bbox column
+                # Mask features use pl.Object
                 self.graph.add_node_attr_key(key, default_value=None, dtype=pl.Object)
-                bbox_key = feature["bbox_key"]
-                if bbox_key not in self.graph.node_attr_keys():
-                    spatial_ndim = self.ndim - 1
-                    self.graph.add_node_attr_key(
-                        bbox_key,
-                        dtype=pl.Array(pl.Int64, 2 * spatial_ndim),
-                    )
             else:
                 dtype = to_polars_dtype(feature["value_type"])
                 num_values = feature.get("num_values")
                 if num_values is not None and num_values > 1:
-                    dtype = pl.Array(pl.Float64, num_values)
+                    dtype = pl.Array(to_polars_dtype(feature["value_type"]), num_values)
                 self.graph.add_node_attr_key(
                     key,
                     default_value=feature["default_value"],
@@ -758,6 +752,12 @@ class Tracks:
         # Remove from the features dictionary
         del self.features[key]
 
+        # Cascade-delete any derived features
+        if feature is not None:
+            for derived_key in feature.get("derived_features", []):
+                if derived_key in self.features:
+                    self.delete_feature(derived_key)
+
         # Determine feature_type from FeatureDict entry or annotators
         if feature is not None:
             feature_type = feature["feature_type"]
@@ -769,10 +769,5 @@ class Tracks:
         # Perform custom graph operations when a feature is deleted
         if feature_type == "node" and key in self.graph.node_attr_keys():
             self.graph.remove_node_attr_key(key)
-            # For mask features, also remove the paired bbox column
-            if feature is not None and feature.get("value_type") == "mask":
-                bbox_key = feature.get("bbox_key")
-                if bbox_key and bbox_key in self.graph.node_attr_keys():
-                    self.graph.remove_node_attr_key(bbox_key)
         elif feature_type == "edge" and key in self.graph.edge_attr_keys():
             self.graph.remove_edge_attr_key(key)

--- a/src/funtracks/features/__init__.py
+++ b/src/funtracks/features/__init__.py
@@ -1,7 +1,7 @@
 from ._edge_features import IoU
 from ._feature import Feature, ValueType
 from ._feature_dict import FeatureDict
-from ._node_features import Position, SegMask, Solution, Time
+from ._node_features import Position, SegMask, Time
 from ._regionprops_features import (
     Area,
     Circularity,
@@ -17,7 +17,6 @@ __all__ = [
     "FeatureDict",
     "Position",
     "SegMask",
-    "Solution",
     "Time",
     "EllipsoidAxes",
     "Circularity",

--- a/src/funtracks/features/__init__.py
+++ b/src/funtracks/features/__init__.py
@@ -1,7 +1,7 @@
 from ._edge_features import IoU
 from ._feature import Feature, ValueType
 from ._feature_dict import FeatureDict
-from ._node_features import Position, Time
+from ._node_features import Position, SegMask, Solution, Time
 from ._regionprops_features import (
     Area,
     Circularity,
@@ -16,6 +16,8 @@ __all__ = [
     "ValueType",
     "FeatureDict",
     "Position",
+    "SegMask",
+    "Solution",
     "Time",
     "EllipsoidAxes",
     "Circularity",

--- a/src/funtracks/features/__init__.py
+++ b/src/funtracks/features/__init__.py
@@ -1,7 +1,7 @@
 from ._edge_features import IoU
 from ._feature import Feature, ValueType
 from ._feature_dict import FeatureDict
-from ._node_features import Position, SegMask, Time
+from ._node_features import Position, SegBbox, SegMask, Time
 from ._regionprops_features import (
     Area,
     Circularity,
@@ -16,6 +16,7 @@ __all__ = [
     "ValueType",
     "FeatureDict",
     "Position",
+    "SegBbox",
     "SegMask",
     "Time",
     "EllipsoidAxes",

--- a/src/funtracks/features/_feature.py
+++ b/src/funtracks/features/_feature.py
@@ -31,6 +31,10 @@ class Feature(TypedDict):
         spatial_dims (bool): Optional. If True, num_values must match the number
             of spatial dimensions (e.g., 2 for 2D, 3 for 3D). Used for features
             like Position and EllipsoidAxes.
+        derived_features (list[str]): Optional. Feature keys that are derived
+            from this feature and should be cascade-deleted when this feature
+            is removed. For example, SegMask lists the bbox key here so that
+            deleting the mask also deletes the bounding box.
     """
 
     feature_type: Literal["node", "edge"]
@@ -40,4 +44,4 @@ class Feature(TypedDict):
     value_names: NotRequired[Sequence[str]]
     default_value: Any
     spatial_dims: NotRequired[bool]
-    bbox_key: NotRequired[str]
+    derived_features: NotRequired[list[str]]

--- a/src/funtracks/features/_feature.py
+++ b/src/funtracks/features/_feature.py
@@ -6,7 +6,7 @@ from typing import Any, Literal, TypedDict
 from typing_extensions import NotRequired
 
 # Type alias for feature value types
-ValueType = Literal["int", "float", "str", "bool"]
+ValueType = Literal["int", "float", "str", "bool", "mask"]
 
 
 class Feature(TypedDict):
@@ -40,3 +40,4 @@ class Feature(TypedDict):
     value_names: NotRequired[Sequence[str]]
     default_value: Any
     spatial_dims: NotRequired[bool]
+    bbox_key: NotRequired[str]

--- a/src/funtracks/features/_node_features.py
+++ b/src/funtracks/features/_node_features.py
@@ -48,21 +48,6 @@ def SegMask(bbox_key: str = "bbox") -> Feature:
     }
 
 
-def Solution() -> Feature:
-    """A feature to hold the integer solution value for a node.
-
-    Returns:
-        Feature: A feature dict representing solution status.
-    """
-    return {
-        "feature_type": "node",
-        "value_type": "int",
-        "num_values": 1,
-        "display_name": "Solution",
-        "default_value": 1,
-    }
-
-
 def Position(axes: Sequence[str]) -> Feature:
     """A feature to hold the position of a node (time not included).
 

--- a/src/funtracks/features/_node_features.py
+++ b/src/funtracks/features/_node_features.py
@@ -23,6 +23,46 @@ def Time() -> Feature:
     }
 
 
+def SegMask(bbox_key: str = "bbox") -> Feature:
+    """A feature to hold a segmentation mask for a node.
+
+    The mask is stored as a pl.Object column. The paired bounding box
+    column (``bbox_key``) is implied — it is NOT a separate Feature in
+    the FeatureDict, but is automatically created/deleted alongside the
+    mask column.
+
+    Args:
+        bbox_key: The node attribute key for the paired bounding box
+            column. Defaults to ``"bbox"``.
+
+    Returns:
+        Feature: A feature dict representing a segmentation mask.
+    """
+    return {
+        "feature_type": "node",
+        "value_type": "mask",
+        "num_values": 1,
+        "display_name": "Segmentation mask",
+        "default_value": None,
+        "bbox_key": bbox_key,
+    }
+
+
+def Solution() -> Feature:
+    """A feature to hold the integer solution value for a node.
+
+    Returns:
+        Feature: A feature dict representing solution status.
+    """
+    return {
+        "feature_type": "node",
+        "value_type": "int",
+        "num_values": 1,
+        "display_name": "Solution",
+        "default_value": 1,
+    }
+
+
 def Position(axes: Sequence[str]) -> Feature:
     """A feature to hold the position of a node (time not included).
 

--- a/src/funtracks/features/_node_features.py
+++ b/src/funtracks/features/_node_features.py
@@ -23,17 +23,17 @@ def Time() -> Feature:
     }
 
 
-def SegMask(bbox_key: str = "bbox") -> Feature:
+def SegMask(ndim: int, bbox_key: str = "bbox") -> Feature:
     """A feature to hold a segmentation mask for a node.
 
-    The mask is stored as a pl.Object column. The paired bounding box
-    column (``bbox_key``) is implied — it is NOT a separate Feature in
-    the FeatureDict, but is automatically created/deleted alongside the
-    mask column.
+    The mask is stored as a pl.Object column. The ``derived_features``
+    list records keys (e.g. the bounding-box key) that should be
+    cascade-deleted when this mask feature is removed.
 
     Args:
+        ndim: Number of dimensions (3 for 2D+time, 4 for 3D+time).
         bbox_key: The node attribute key for the paired bounding box
-            column. Defaults to ``"bbox"``.
+            feature. Defaults to ``"bbox"``.
 
     Returns:
         Feature: A feature dict representing a segmentation mask.
@@ -44,7 +44,29 @@ def SegMask(bbox_key: str = "bbox") -> Feature:
         "num_values": 1,
         "display_name": "Segmentation mask",
         "default_value": None,
-        "bbox_key": bbox_key,
+        "derived_features": [bbox_key],
+    }
+
+
+def SegBbox(ndim: int) -> Feature:
+    """A feature to hold the bounding box for a segmentation mask.
+
+    The bounding box is stored as a fixed-size integer array with
+    ``2 * spatial_ndim`` values (min coords followed by max coords).
+
+    Args:
+        ndim: Number of dimensions (3 for 2D+time, 4 for 3D+time).
+
+    Returns:
+        Feature: A feature dict representing a bounding box.
+    """
+    spatial_ndim = ndim - 1
+    return {
+        "feature_type": "node",
+        "value_type": "int",
+        "num_values": 2 * spatial_ndim,
+        "display_name": "Bounding box",
+        "default_value": None,
     }
 
 

--- a/src/funtracks/import_export/_v1_format.py
+++ b/src/funtracks/import_export/_v1_format.py
@@ -9,7 +9,7 @@ import networkx as nx
 import numpy as np
 import tracksdata as td
 
-from funtracks.features import FeatureDict, SegMask, Solution
+from funtracks.features import FeatureDict, SegMask
 from funtracks.utils.tracksdata_utils import (
     add_masks_and_bboxes_to_graph,
     convert_graph_nx_to_td,
@@ -88,19 +88,15 @@ def load_v1_tracks(
     if seg is not None:
         graph_td = add_masks_and_bboxes_to_graph(graph_td, seg)
 
-    # Ensure mask and solution Features are in the FeatureDict (older saves
-    # predate their registration as Features).
+    # Ensure mask Feature is in the FeatureDict (older saves predate
+    # its registration as a Feature).
     features = attrs.get("features")
-    if isinstance(features, FeatureDict):
-        if seg is not None and td.DEFAULT_ATTR_KEYS.MASK not in features:
-            features[td.DEFAULT_ATTR_KEYS.MASK] = SegMask(
-                bbox_key=td.DEFAULT_ATTR_KEYS.BBOX
-            )
-        if (
-            td.DEFAULT_ATTR_KEYS.SOLUTION not in features
-            and td.DEFAULT_ATTR_KEYS.SOLUTION in graph_td.node_attr_keys()
-        ):
-            features[td.DEFAULT_ATTR_KEYS.SOLUTION] = Solution()
+    if (
+        isinstance(features, FeatureDict)
+        and seg is not None
+        and td.DEFAULT_ATTR_KEYS.MASK not in features
+    ):
+        features[td.DEFAULT_ATTR_KEYS.MASK] = SegMask(bbox_key=td.DEFAULT_ATTR_KEYS.BBOX)
 
     # filtering the warnings because the default values of time_attr and pos_attr are
     # not None. Therefore, new style Tracks attrs that have features instead of

--- a/src/funtracks/import_export/_v1_format.py
+++ b/src/funtracks/import_export/_v1_format.py
@@ -9,7 +9,7 @@ import networkx as nx
 import numpy as np
 import tracksdata as td
 
-from funtracks.features import FeatureDict, SegMask
+from funtracks.features import FeatureDict, SegBbox, SegMask
 from funtracks.utils.tracksdata_utils import (
     add_masks_and_bboxes_to_graph,
     convert_graph_nx_to_td,
@@ -88,15 +88,19 @@ def load_v1_tracks(
     if seg is not None:
         graph_td = add_masks_and_bboxes_to_graph(graph_td, seg)
 
-    # Ensure mask Feature is in the FeatureDict (older saves predate
-    # its registration as a Feature).
+    # Ensure mask and bbox Features are in the FeatureDict (older saves
+    # predate their registration as Features).
     features = attrs.get("features")
+    ndim = attrs.get("ndim", len(seg.shape) if seg is not None else 3)
     if (
         isinstance(features, FeatureDict)
         and seg is not None
         and td.DEFAULT_ATTR_KEYS.MASK not in features
     ):
-        features[td.DEFAULT_ATTR_KEYS.MASK] = SegMask(bbox_key=td.DEFAULT_ATTR_KEYS.BBOX)
+        features[td.DEFAULT_ATTR_KEYS.MASK] = SegMask(
+            ndim, bbox_key=td.DEFAULT_ATTR_KEYS.BBOX
+        )
+        features[td.DEFAULT_ATTR_KEYS.BBOX] = SegBbox(ndim)
 
     # filtering the warnings because the default values of time_attr and pos_attr are
     # not None. Therefore, new style Tracks attrs that have features instead of

--- a/src/funtracks/import_export/_v1_format.py
+++ b/src/funtracks/import_export/_v1_format.py
@@ -7,8 +7,9 @@ from typing import TYPE_CHECKING
 
 import networkx as nx
 import numpy as np
+import tracksdata as td
 
-from funtracks.features import FeatureDict
+from funtracks.features import FeatureDict, SegMask, Solution
 from funtracks.utils.tracksdata_utils import (
     add_masks_and_bboxes_to_graph,
     convert_graph_nx_to_td,
@@ -86,6 +87,20 @@ def load_v1_tracks(
     # Add mask and bbox attributes to graph if segmentation is available
     if seg is not None:
         graph_td = add_masks_and_bboxes_to_graph(graph_td, seg)
+
+    # Ensure mask and solution Features are in the FeatureDict (older saves
+    # predate their registration as Features).
+    features = attrs.get("features")
+    if isinstance(features, FeatureDict):
+        if seg is not None and td.DEFAULT_ATTR_KEYS.MASK not in features:
+            features[td.DEFAULT_ATTR_KEYS.MASK] = SegMask(
+                bbox_key=td.DEFAULT_ATTR_KEYS.BBOX
+            )
+        if (
+            td.DEFAULT_ATTR_KEYS.SOLUTION not in features
+            and td.DEFAULT_ATTR_KEYS.SOLUTION in graph_td.node_attr_keys()
+        ):
+            features[td.DEFAULT_ATTR_KEYS.SOLUTION] = Solution()
 
     # filtering the warnings because the default values of time_attr and pos_attr are
     # not None. Therefore, new style Tracks attrs that have features instead of

--- a/src/funtracks/import_export/csv/_export.py
+++ b/src/funtracks/import_export/csv/_export.py
@@ -106,11 +106,20 @@ def export_to_csv(
     # For display names mode, build dynamic header from features
     feature_names = []
     if use_display_names:
+        # Collect derived feature keys to skip
+        derived_keys: set[str] = set()
+        for fd in tracks.features.values():
+            for dk in fd.get("derived_features", []):
+                derived_keys.add(dk)
+
         for feature_name, feature_dict in tracks.features.items():
             if feature_dict["feature_type"] != "node":
                 continue
             # Skip mask features — they contain binary objects, not scalar values
             if feature_dict.get("value_type") == "mask":
+                continue
+            # Skip derived features (e.g. bbox managed by mask)
+            if feature_name in derived_keys:
                 continue
             feature_names.append(feature_name)
             num_values = feature_dict.get("num_values", 1)

--- a/src/funtracks/import_export/csv/_export.py
+++ b/src/funtracks/import_export/csv/_export.py
@@ -107,6 +107,9 @@ def export_to_csv(
     feature_names = []
     if use_display_names:
         for feature_name, feature_dict in tracks.features.items():
+            # Skip mask features — they contain binary objects, not scalar values
+            if feature_dict.get("value_type") == "mask":
+                continue
             feature_names.append(feature_name)
             num_values = feature_dict.get("num_values", 1)
 

--- a/src/funtracks/import_export/csv/_export.py
+++ b/src/funtracks/import_export/csv/_export.py
@@ -109,8 +109,8 @@ def export_to_csv(
         # Collect derived feature keys to skip
         derived_keys: set[str] = set()
         for fd in tracks.features.values():
-            for dk in fd.get("derived_features", []):
-                derived_keys.add(dk)
+            for derived_key in fd.get("derived_features", []):
+                derived_keys.add(derived_key)
 
         for feature_name, feature_dict in tracks.features.items():
             if feature_dict["feature_type"] != "node":

--- a/src/funtracks/user_actions/user_add_node.py
+++ b/src/funtracks/user_actions/user_add_node.py
@@ -4,6 +4,7 @@ import warnings
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
+import tracksdata as td
 
 from funtracks.exceptions import InvalidActionError
 from funtracks.utils.tracksdata_utils import pixels_to_td_mask
@@ -149,9 +150,17 @@ class UserAddNode(ActionGroup):
         # remove skip edge that will be replaced by new edges after adding nodes
         if pred is not None and succ is not None:
             self.actions.append(DeleteEdge(tracks, (pred, succ)))
+        # put mask+bbox into attributes
+        if pixels is not None:
+            mask = pixels_to_td_mask(pixels, self.tracks.ndim)
+            mask_key = td.DEFAULT_ATTR_KEYS.MASK
+            attributes[mask_key] = mask
+            mask_feature = tracks.features.get(mask_key)
+            if mask_feature is not None:
+                for derived_key in mask_feature.get("derived_features", []):
+                    attributes[derived_key] = mask.bbox
+        self.actions.append(AddNode(tracks, node, attributes))
         # add predecessor and successor edges
-        mask = pixels_to_td_mask(pixels, self.tracks.ndim) if pixels is not None else None
-        self.actions.append(AddNode(tracks, node, attributes, mask))
         if pred is not None:
             self.actions.append(AddEdge(tracks, (pred, node)))
         if succ is not None:

--- a/src/funtracks/user_actions/user_delete_node.py
+++ b/src/funtracks/user_actions/user_delete_node.py
@@ -4,10 +4,6 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 
-from funtracks.utils.tracksdata_utils import (
-    pixels_to_td_mask,
-)
-
 from ..actions._base import ActionGroup
 from ..actions.add_delete_edge import AddEdge, DeleteEdge
 from ..actions.add_delete_node import DeleteNode
@@ -62,12 +58,7 @@ class UserDeleteNode(ActionGroup):
                 self.actions.append(AddEdge(tracks, (predecessor, successor)))
 
         # delete node
-        mask = (
-            pixels_to_td_mask(pixels, ndim=self.tracks.ndim)
-            if pixels is not None
-            else None
-        )
-        self.actions.append(DeleteNode(tracks, node, mask=mask))
+        self.actions.append(DeleteNode(tracks, node))
 
         if _top_level:
             self.tracks.action_history.add_new_action(self)

--- a/src/funtracks/utils/tracksdata_utils.py
+++ b/src/funtracks/utils/tracksdata_utils.py
@@ -40,6 +40,7 @@ def to_polars_dtype(dtype_or_value: str | Any) -> pl.DataType:
         "int": pl.Int64,
         "float": pl.Float64,
         "bool": pl.Boolean,
+        "mask": pl.Object,
         "datetime": pl.Datetime,
         "date": pl.Date,
     }

--- a/tests/actions/test_add_delete_nodes.py
+++ b/tests/actions/test_add_delete_nodes.py
@@ -53,8 +53,6 @@ def test_add_delete_nodes(get_tracks, ndim, with_seg):
 
     actions = []
     for node in nodes:
-        mask = reference_graph.nodes[node]["mask"] if with_seg else None
-
         attrs = {}
         attrs[tracks.features.time_key] = reference_graph.nodes[node][
             tracks.features.time_key
@@ -77,7 +75,7 @@ def test_add_delete_nodes(get_tracks, ndim, with_seg):
             attrs["bbox"] = reference_graph.nodes[node]["bbox"]
             attrs["mask"] = reference_graph.nodes[node]["mask"]
 
-        actions.append(AddNode(tracks, node, attributes=attrs, mask=mask))
+        actions.append(AddNode(tracks, node, attributes=attrs))
     action = ActionGroup(tracks=tracks, actions=actions)
 
     assert set(tracks.graph.node_ids()) == set(reference_graph.node_ids())
@@ -188,20 +186,16 @@ def test_custom_attributes_preserved(get_tracks, ndim, with_seg):
     # Create segmentation if needed
     if with_seg:
         if ndim == 3:
-            # Create 2D mask centered at (50, 50) with radius 5
-            mask = make_2d_disk_mask(center=(50, 50), radius=5)
+            seg_mask = make_2d_disk_mask(center=(50, 50), radius=5)
         else:
-            # Create proper 4D pixel coordinates (t, z, y, x)
-            mask = make_3d_sphere_mask(center=(50, 50, 50), radius=5)
-        custom_attrs["mask"] = mask
-        custom_attrs["bbox"] = mask.bbox
+            seg_mask = make_3d_sphere_mask(center=(50, 50, 50), radius=5)
+        custom_attrs["mask"] = seg_mask
+        custom_attrs["bbox"] = seg_mask.bbox
         custom_attrs.pop("pos")  # pos will be computed from segmentation
-    else:
-        mask = None
 
     # Add a node with custom attributes
     node_id = 100
-    action = AddNode(tracks, node_id, custom_attrs.copy(), mask=mask)
+    action = AddNode(tracks, node_id, custom_attrs.copy())
     # Verify all attributes are present after adding
     assert tracks.graph.has_node(node_id)
     for key, value in custom_attrs.items():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -368,7 +368,6 @@ def get_tracks(get_graph) -> Callable[..., "Tracks | SolutionTracks"]:
         LineageID,
         Position,
         SegMask,
-        Solution,
         Time,
         TrackletID,
     )
@@ -393,8 +392,6 @@ def get_tracks(get_graph) -> Callable[..., "Tracks | SolutionTracks"]:
             features_dict["mask"] = SegMask()
             features_dict["area"] = Area(ndim=ndim)
             features_dict["iou"] = IoU()
-        # Solution is always on the test graph (set by _make_graph)
-        features_dict["solution"] = Solution()
         if is_solution:
             features_dict["track_id"] = TrackletID()
             features_dict["lineage_id"] = LineageID()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -367,6 +367,7 @@ def get_tracks(get_graph) -> Callable[..., "Tracks | SolutionTracks"]:
         IoU,
         LineageID,
         Position,
+        SegBbox,
         SegMask,
         Time,
         TrackletID,
@@ -389,7 +390,8 @@ def get_tracks(get_graph) -> Callable[..., "Tracks | SolutionTracks"]:
         }
 
         if with_seg:
-            features_dict["mask"] = SegMask()
+            features_dict["mask"] = SegMask(ndim)
+            features_dict["bbox"] = SegBbox(ndim)
             features_dict["area"] = Area(ndim=ndim)
             features_dict["iou"] = IoU()
         if is_solution:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -367,6 +367,8 @@ def get_tracks(get_graph) -> Callable[..., "Tracks | SolutionTracks"]:
         IoU,
         LineageID,
         Position,
+        SegMask,
+        Solution,
         Time,
         TrackletID,
     )
@@ -388,8 +390,11 @@ def get_tracks(get_graph) -> Callable[..., "Tracks | SolutionTracks"]:
         }
 
         if with_seg:
+            features_dict["mask"] = SegMask()
             features_dict["area"] = Area(ndim=ndim)
             features_dict["iou"] = IoU()
+        # Solution is always on the test graph (set by _make_graph)
+        features_dict["solution"] = Solution()
         if is_solution:
             features_dict["track_id"] = TrackletID()
             features_dict["lineage_id"] = LineageID()

--- a/tests/data_model/test_solution_tracks.py
+++ b/tests/data_model/test_solution_tracks.py
@@ -127,8 +127,19 @@ def test_export_to_csv_with_display_names(
 
     assert len(lines) == tracks.graph.num_nodes() + 1  # add header
 
-    # With display names: ID, Parent ID, Time, y, x, Tracklet ID, Lineage ID, Area
-    header = ["ID", "Parent ID", "Time", "y", "x", "Tracklet ID", "Lineage ID", "Area"]
+    # With display names:
+    # ID, Parent ID, Time, Solution, y, x, Tracklet ID, Lineage ID, Area
+    header = [
+        "ID",
+        "Parent ID",
+        "Time",
+        "Solution",
+        "y",
+        "x",
+        "Tracklet ID",
+        "Lineage ID",
+        "Area",
+    ]
     assert lines[0].strip().split(",") == header
 
     # Test 3D with display names (area display name is "Volume" in 3D)
@@ -141,11 +152,13 @@ def test_export_to_csv_with_display_names(
 
     assert len(lines) == tracks.graph.num_nodes() + 1  # add header
 
-    # With display names: ID, Parent ID, Time, z, y, x, Tracklet ID, Lineage ID, Volume
+    # With display names:
+    # ID, Parent ID, Time, Solution, z, y, x, Tracklet ID, Lineage ID, Volume
     header = [
         "ID",
         "Parent ID",
         "Time",
+        "Solution",
         "z",
         "y",
         "x",

--- a/tests/data_model/test_solution_tracks.py
+++ b/tests/data_model/test_solution_tracks.py
@@ -127,19 +127,8 @@ def test_export_to_csv_with_display_names(
 
     assert len(lines) == tracks.graph.num_nodes() + 1  # add header
 
-    # With display names:
-    # ID, Parent ID, Time, Solution, y, x, Tracklet ID, Lineage ID, Area
-    header = [
-        "ID",
-        "Parent ID",
-        "Time",
-        "Solution",
-        "y",
-        "x",
-        "Tracklet ID",
-        "Lineage ID",
-        "Area",
-    ]
+    # With display names: ID, Parent ID, Time, y, x, Tracklet ID, Lineage ID, Area
+    header = ["ID", "Parent ID", "Time", "y", "x", "Tracklet ID", "Lineage ID", "Area"]
     assert lines[0].strip().split(",") == header
 
     # Test 3D with display names (area display name is "Volume" in 3D)
@@ -152,13 +141,11 @@ def test_export_to_csv_with_display_names(
 
     assert len(lines) == tracks.graph.num_nodes() + 1  # add header
 
-    # With display names:
-    # ID, Parent ID, Time, Solution, z, y, x, Tracklet ID, Lineage ID, Volume
+    # With display names: ID, Parent ID, Time, z, y, x, Tracklet ID, Lineage ID, Volume
     header = [
         "ID",
         "Parent ID",
         "Time",
-        "Solution",
         "z",
         "y",
         "x",

--- a/tests/data_model/test_tracks.py
+++ b/tests/data_model/test_tracks.py
@@ -282,19 +282,15 @@ def test_undo_redo(graph_2d_with_segmentation):
     assert tracks.get_node_attr(2, "another_label") == "second_value"
 
 
-def test_get_feature_set_registers_mask_and_solution(
+def test_get_feature_set_registers_mask(
     graph_2d_with_segmentation,
 ):
-    """_get_feature_set registers mask and solution as Features when present."""
+    """_get_feature_set registers mask as a Feature when segmentation exists."""
     tracks = Tracks(graph_2d_with_segmentation, ndim=3, **track_attrs)
 
     assert "mask" in tracks.features
     assert tracks.features["mask"]["value_type"] == "mask"
     assert tracks.features["mask"]["bbox_key"] == "bbox"
-
-    assert "solution" in tracks.features
-    assert tracks.features["solution"]["value_type"] == "int"
-    assert tracks.features["solution"]["default_value"] == 1
 
 
 def test_get_feature_set_no_mask_without_segmentation(

--- a/tests/data_model/test_tracks.py
+++ b/tests/data_model/test_tracks.py
@@ -5,7 +5,7 @@ import tracksdata as td
 
 from funtracks.actions import UpdateNodeAttrs
 from funtracks.data_model import Tracks
-from funtracks.features import SegMask
+from funtracks.features import SegBbox, SegMask
 from funtracks.user_actions import UserUpdateSegmentation
 from funtracks.utils.tracksdata_utils import (
     create_empty_graphview_graph,
@@ -285,12 +285,14 @@ def test_undo_redo(graph_2d_with_segmentation):
 def test_get_feature_set_registers_mask(
     graph_2d_with_segmentation,
 ):
-    """_get_feature_set registers mask as a Feature when segmentation exists."""
+    """_get_feature_set registers mask and bbox as Features when segmentation exists."""
     tracks = Tracks(graph_2d_with_segmentation, ndim=3, **track_attrs)
 
     assert "mask" in tracks.features
     assert tracks.features["mask"]["value_type"] == "mask"
-    assert tracks.features["mask"]["bbox_key"] == "bbox"
+    assert tracks.features["mask"]["derived_features"] == ["bbox"]
+    assert "bbox" in tracks.features
+    assert tracks.features["bbox"]["value_type"] == "int"
 
 
 def test_get_feature_set_no_mask_without_segmentation(
@@ -307,32 +309,36 @@ def test_to_polars_dtype_mask():
 
 
 def test_add_feature_mask_creates_both_columns():
-    """add_feature with a mask Feature creates both mask and bbox columns."""
+    """add_feature with mask and bbox Features creates both columns."""
     graph = create_empty_graphview_graph(ndim=3)
     tracks = Tracks(graph, ndim=3, **track_attrs)
 
     assert "nuc_mask" not in tracks.graph.node_attr_keys()
     assert "nuc_bbox" not in tracks.graph.node_attr_keys()
 
-    tracks.add_feature("nuc_mask", SegMask(bbox_key="nuc_bbox"))
+    tracks.add_feature("nuc_mask", SegMask(ndim=3, bbox_key="nuc_bbox"))
+    tracks.add_feature("nuc_bbox", SegBbox(ndim=3))
 
     assert "nuc_mask" in tracks.graph.node_attr_keys()
     assert "nuc_bbox" in tracks.graph.node_attr_keys()
     assert "nuc_mask" in tracks.features
+    assert "nuc_bbox" in tracks.features
 
 
 def test_delete_feature_mask_removes_both_columns(
     graph_2d_with_segmentation,
 ):
-    """delete_feature on a mask Feature removes both mask and bbox columns."""
+    """delete_feature on a mask Feature removes both mask and bbox columns (cascade)."""
     tracks = Tracks(graph_2d_with_segmentation, ndim=3, **track_attrs)
 
     assert "mask" in tracks.features
+    assert "bbox" in tracks.features
     assert "mask" in tracks.graph.node_attr_keys()
     assert "bbox" in tracks.graph.node_attr_keys()
 
     tracks.delete_feature("mask")
 
     assert "mask" not in tracks.features
+    assert "bbox" not in tracks.features
     assert "mask" not in tracks.graph.node_attr_keys()
     assert "bbox" not in tracks.graph.node_attr_keys()

--- a/tests/data_model/test_tracks.py
+++ b/tests/data_model/test_tracks.py
@@ -342,3 +342,19 @@ def test_delete_feature_mask_removes_both_columns(
     assert "bbox" not in tracks.features
     assert "mask" not in tracks.graph.node_attr_keys()
     assert "bbox" not in tracks.graph.node_attr_keys()
+
+
+def test_update_mask_syncs_bbox(graph_2d_with_segmentation):
+    """update_mask writes both the mask and bbox to the graph node."""
+    from tests.conftest import make_2d_disk_mask
+
+    tracks = Tracks(graph_2d_with_segmentation, ndim=3, **track_attrs)
+
+    new_mask = make_2d_disk_mask(center=(30, 30), radius=10)
+    tracks.update_mask(1, new_mask)
+
+    stored_mask = tracks.graph.nodes[1][td.DEFAULT_ATTR_KEYS.MASK]
+    stored_bbox = tracks.graph.nodes[1][td.DEFAULT_ATTR_KEYS.BBOX]
+
+    assert stored_mask is new_mask
+    assert np.array_equal(stored_bbox, new_mask.bbox)

--- a/tests/data_model/test_tracks.py
+++ b/tests/data_model/test_tracks.py
@@ -5,9 +5,11 @@ import tracksdata as td
 
 from funtracks.actions import UpdateNodeAttrs
 from funtracks.data_model import Tracks
+from funtracks.features import SegMask
 from funtracks.user_actions import UserUpdateSegmentation
 from funtracks.utils.tracksdata_utils import (
     create_empty_graphview_graph,
+    to_polars_dtype,
 )
 
 track_attrs = {"time_attr": "t", "tracklet_attr": "track_id"}
@@ -278,3 +280,63 @@ def test_undo_redo(graph_2d_with_segmentation):
 
     assert tracks.redo() is True  # Redo second action
     assert tracks.get_node_attr(2, "another_label") == "second_value"
+
+
+def test_get_feature_set_registers_mask_and_solution(
+    graph_2d_with_segmentation,
+):
+    """_get_feature_set registers mask and solution as Features when present."""
+    tracks = Tracks(graph_2d_with_segmentation, ndim=3, **track_attrs)
+
+    assert "mask" in tracks.features
+    assert tracks.features["mask"]["value_type"] == "mask"
+    assert tracks.features["mask"]["bbox_key"] == "bbox"
+
+    assert "solution" in tracks.features
+    assert tracks.features["solution"]["value_type"] == "int"
+    assert tracks.features["solution"]["default_value"] == 1
+
+
+def test_get_feature_set_no_mask_without_segmentation(
+    graph_2d_with_position,
+):
+    """_get_feature_set does NOT register mask when there is no segmentation."""
+    tracks = Tracks(graph_2d_with_position, ndim=3, **track_attrs)
+    assert "mask" not in tracks.features
+
+
+def test_to_polars_dtype_mask():
+    """to_polars_dtype maps 'mask' to pl.Object."""
+    assert to_polars_dtype("mask") == pl.Object
+
+
+def test_add_feature_mask_creates_both_columns():
+    """add_feature with a mask Feature creates both mask and bbox columns."""
+    graph = create_empty_graphview_graph(ndim=3)
+    tracks = Tracks(graph, ndim=3, **track_attrs)
+
+    assert "nuc_mask" not in tracks.graph.node_attr_keys()
+    assert "nuc_bbox" not in tracks.graph.node_attr_keys()
+
+    tracks.add_feature("nuc_mask", SegMask(bbox_key="nuc_bbox"))
+
+    assert "nuc_mask" in tracks.graph.node_attr_keys()
+    assert "nuc_bbox" in tracks.graph.node_attr_keys()
+    assert "nuc_mask" in tracks.features
+
+
+def test_delete_feature_mask_removes_both_columns(
+    graph_2d_with_segmentation,
+):
+    """delete_feature on a mask Feature removes both mask and bbox columns."""
+    tracks = Tracks(graph_2d_with_segmentation, ndim=3, **track_attrs)
+
+    assert "mask" in tracks.features
+    assert "mask" in tracks.graph.node_attr_keys()
+    assert "bbox" in tracks.graph.node_attr_keys()
+
+    tracks.delete_feature("mask")
+
+    assert "mask" not in tracks.features
+    assert "mask" not in tracks.graph.node_attr_keys()
+    assert "bbox" not in tracks.graph.node_attr_keys()

--- a/tests/features/test_node_features.py
+++ b/tests/features/test_node_features.py
@@ -4,6 +4,7 @@ from funtracks.features import (
     EllipsoidAxes,
     Perimeter,
     Position,
+    SegBbox,
     SegMask,
     Time,
 )
@@ -86,17 +87,32 @@ def test_perimeter_feature():
 
 def test_seg_mask_feature():
     """Test that SegMask() returns a valid Feature TypedDict"""
-    feat = SegMask()
+    feat = SegMask(ndim=3)
     assert feat["feature_type"] == "node"
     assert feat["value_type"] == "mask"
     assert feat["num_values"] == 1
     assert feat["display_name"] == "Segmentation mask"
     assert feat["default_value"] is None
-    assert feat["bbox_key"] == "bbox"
+    assert feat["derived_features"] == ["bbox"]
 
     # Custom bbox_key
-    feat = SegMask(bbox_key="nuc_bbox")
-    assert feat["bbox_key"] == "nuc_bbox"
+    feat = SegMask(ndim=3, bbox_key="nuc_bbox")
+    assert feat["derived_features"] == ["nuc_bbox"]
+
+
+def test_seg_bbox_feature():
+    """Test that SegBbox() returns a valid Feature TypedDict"""
+    # ndim=3 means 2D+time -> 2 spatial dimensions -> 4 bbox values
+    feat = SegBbox(ndim=3)
+    assert feat["feature_type"] == "node"
+    assert feat["value_type"] == "int"
+    assert feat["num_values"] == 4
+    assert feat["display_name"] == "Bounding box"
+    assert feat["default_value"] is None
+
+    # ndim=4 means 3D+time -> 3 spatial dimensions -> 6 bbox values
+    feat = SegBbox(ndim=4)
+    assert feat["num_values"] == 6
 
 
 def test_feature_as_dict():

--- a/tests/features/test_node_features.py
+++ b/tests/features/test_node_features.py
@@ -5,7 +5,6 @@ from funtracks.features import (
     Perimeter,
     Position,
     SegMask,
-    Solution,
     Time,
 )
 
@@ -98,16 +97,6 @@ def test_seg_mask_feature():
     # Custom bbox_key
     feat = SegMask(bbox_key="nuc_bbox")
     assert feat["bbox_key"] == "nuc_bbox"
-
-
-def test_solution_feature():
-    """Test that Solution() returns a valid Feature TypedDict"""
-    feat = Solution()
-    assert feat["feature_type"] == "node"
-    assert feat["value_type"] == "int"
-    assert feat["num_values"] == 1
-    assert feat["display_name"] == "Solution"
-    assert feat["default_value"] == 1
 
 
 def test_feature_as_dict():

--- a/tests/features/test_node_features.py
+++ b/tests/features/test_node_features.py
@@ -4,6 +4,8 @@ from funtracks.features import (
     EllipsoidAxes,
     Perimeter,
     Position,
+    SegMask,
+    Solution,
     Time,
 )
 
@@ -81,6 +83,31 @@ def test_perimeter_feature():
 
     feat = Perimeter(ndim=4)
     assert feat["display_name"] == "Surface Area"
+
+
+def test_seg_mask_feature():
+    """Test that SegMask() returns a valid Feature TypedDict"""
+    feat = SegMask()
+    assert feat["feature_type"] == "node"
+    assert feat["value_type"] == "mask"
+    assert feat["num_values"] == 1
+    assert feat["display_name"] == "Segmentation mask"
+    assert feat["default_value"] is None
+    assert feat["bbox_key"] == "bbox"
+
+    # Custom bbox_key
+    feat = SegMask(bbox_key="nuc_bbox")
+    assert feat["bbox_key"] == "nuc_bbox"
+
+
+def test_solution_feature():
+    """Test that Solution() returns a valid Feature TypedDict"""
+    feat = Solution()
+    assert feat["feature_type"] == "node"
+    assert feat["value_type"] == "int"
+    assert feat["num_values"] == 1
+    assert feat["display_name"] == "Solution"
+    assert feat["default_value"] == 1
 
 
 def test_feature_as_dict():


### PR DESCRIPTION
## Summary
- Registers `mask` and `bbox` as proper Features in the FeatureDict instead of treating them as special cases
- The bbox is a separate Feature — it is linked to the mask Feature via a `derived_features` field, and is automatically created/deleted/saved alongside the mask column
- Simplifies `DeleteNode` to save/restore mask/bbox node attributes through the generic `node_features` loop, removing hard-coded mask/bbox handling
- This fixes a bug where additional mask attributes (e.g. `nuc_mask`/`nuc_bbox`) would be silently lost on delete/undo