### PR TITLE
exclude non node features from csv export

### DIFF
--- a/src/funtracks/import_export/csv/_export.py
+++ b/src/funtracks/import_export/csv/_export.py
@@ -107,6 +107,8 @@ def export_to_csv(
     feature_names = []
     if use_display_names:
         for feature_name, feature_dict in tracks.features.items():
+            if feature_dict["feature_type"] != "node":
+                continue
             feature_names.append(feature_name)
             num_values = feature_dict.get("num_values", 1)
 

--- a/tests/import_export/test_csv_export.py
+++ b/tests/import_export/test_csv_export.py
@@ -169,3 +169,23 @@ def test_export_filtered_nodes(get_tracks, tmp_path):
 
     # Should have header + node 2 + node 1 (ancestor)
     assert len(lines) == 3  # header + 2 nodes
+
+
+def test_ignore_edge_features_at_export(get_tracks, tmp_path):
+    """Test that edge features are ignored when exporting to csv"""
+
+    tracks = get_tracks(ndim=3, with_seg=True, is_solution=True)
+    temp_file = tmp_path / "test_export_node_features_only.csv"
+
+    # enable node and edge features
+    tracks.enable_features(["iou", "area"])
+
+    # export should not fail
+    export_to_csv(tracks, temp_file, use_display_names=True)
+
+    # Ensure that node feature 'Area' is present but edge feature 'IoU' is not
+    with open(temp_file) as f:
+        lines = f.readlines()
+
+    assert "Area" in lines[0]
+    assert "IoU" not in lines[0]


### PR DESCRIPTION
When exporting to csv with `use_display_names`, we are implicitly requesting all features including edge features, which results in a key error `iou` downstream because we cannot access edge feature via `tracks.get_node_attr`. We should exclude edge features from export to csv (or export them separately) to prevent this error. 

closes https://github.com/funkelab/motile_tracker/issues/421