### PR TITLE
Store and load FeatureDict in GEFF metadata

### DIFF
--- a/src/funtracks/import_export/_tracks_builder.py
+++ b/src/funtracks/import_export/_tracks_builder.py
@@ -763,17 +763,28 @@ class TracksBuilder(ABC):
         # 7. Create SolutionTracks
         # construct_graph() always stores time as "t" (tracksdata convention),
         # regardless of TIME_ATTR, so we pass "t" here explicitly.
-        tracks = SolutionTracks(
-            graph=graph,
-            pos_attr="pos",
-            time_attr="t",
-            ndim=self.ndim,
-            scale=scale,
-        )
+        # If a FeatureDict was loaded (e.g., from GEFF metadata), use it directly
+        if hasattr(self, "features") and self.features is not None:
+            tracks = SolutionTracks(
+                graph=graph,
+                ndim=self.ndim,
+                scale=scale,
+                features=self.features,
+            )
+        else:
+            tracks = SolutionTracks(
+                graph=graph,
+                pos_attr="pos",
+                time_attr="t",
+                ndim=self.ndim,
+                scale=scale,
+            )
 
         # 8. Enable and register features from name maps
-        self.enable_features(tracks, self.node_name_map, feature_type="node")
-        if self.edge_name_map is not None:
-            self.enable_features(tracks, self.edge_name_map, feature_type="edge")
+        # Skip if we already loaded a complete FeatureDict
+        if not (hasattr(self, "features") and self.features is not None):
+            self.enable_features(tracks, self.node_name_map, feature_type="node")
+            if self.edge_name_map is not None:
+                self.enable_features(tracks, self.edge_name_map, feature_type="edge")
 
         return tracks

--- a/src/funtracks/import_export/geff/_export.py
+++ b/src/funtracks/import_export/geff/_export.py
@@ -95,6 +95,11 @@ def export_to_geff(
         node_props_metadata={},
         edge_props_metadata={},
         axes=axes,
+        extra={
+            "funtracks": {
+                "features": tracks.features.dump_json(),
+            }
+        },
     )
 
     # Save segmentation if present and requested

--- a/src/funtracks/import_export/geff/_import.py
+++ b/src/funtracks/import_export/geff/_import.py
@@ -169,6 +169,19 @@ class GeffTracksBuilder(TracksBuilder):
         # Store axes metadata for use in infer_node_name_map
         self._geff_axes = metadata.axes or []
 
+        # Read funtracks FeatureDict from GEFF extra metadata if present
+        # This will be passed to SolutionTracks via the base build() method
+        if metadata.extra and "funtracks" in metadata.extra:
+            funtracks_extra = metadata.extra["funtracks"]
+            if "features" in funtracks_extra:
+                try:
+                    from funtracks.features import FeatureDict
+
+                    self.features = FeatureDict.from_json(funtracks_extra["features"])
+                except (KeyError, ValueError, TypeError):
+                    # If FeatureDict loading fails, features will remain None
+                    pass
+
         # Read segmentation_shape written by export_to_geff (stored as an extra
         # zarr attribute alongside the geff metadata).
         # source_path may be a filesystem Path or an in-memory zarr Store,

--- a/src/funtracks/import_export/geff/_import.py
+++ b/src/funtracks/import_export/geff/_import.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import warnings
 from typing import TYPE_CHECKING
 
 import tracksdata as td
@@ -364,14 +365,28 @@ def import_from_geff(
 
     builder = GeffTracksBuilder()
     builder.prepare(directory)
-    if node_name_map is not None:
+    # When a FeatureDict was loaded from the GEFF metadata, the attribute
+    # names in the graph already match the FeatureDict keys. A user-provided
+    # name_map would rename those columns, making them inconsistent with the
+    # stored FeatureDict. So we only apply the user's name_map when no
+    # FeatureDict was found (i.e. old/external GEFFs).
+    has_feature_dict = getattr(builder, "features", None) is not None
+    if has_feature_dict and (node_name_map is not None or edge_name_map is not None):
+        warnings.warn(
+            "Ignoring user-provided name_map because a FeatureDict was "
+            "loaded from the GEFF metadata. The stored FeatureDict already "
+            "defines the attribute names.",
+            UserWarning,
+            stacklevel=2,
+        )
+    if node_name_map is not None and not has_feature_dict:
         builder.node_name_map = node_name_map
-    if edge_name_map is not None:
+    if edge_name_map is not None and not has_feature_dict:
         builder.edge_name_map = edge_name_map
     return builder.build(
         directory,
         segmentation_path,
         scale=scale,
-        node_name_map=node_name_map,
+        node_name_map=builder.node_name_map,
         database=database,
     )

--- a/tests/import_export/test_import_from_geff.py
+++ b/tests/import_export/test_import_from_geff.py
@@ -2,6 +2,7 @@ import dask.array as da
 import numpy as np
 import pytest
 import tifffile
+import zarr
 from geff.testing.data import create_mock_geff
 
 from funtracks.data_model import SolutionTracks
@@ -981,3 +982,36 @@ def test_featuredict_survives_geff_roundtrip(tmp_path):
     assert imported.features.position_key == st.features.position_key
     assert imported.features.tracklet_key == st.features.tracklet_key
     assert imported.features.lineage_key == st.features.lineage_key
+
+
+def test_invalid_featuredict_in_geff_falls_back_to_autodetect(get_tracks, tmp_path):
+    """If the stored FeatureDict JSON is corrupted or invalid,
+    import_from_geff should silently fall back to auto-detection
+    instead of raising an exception.
+    """
+    tracks = get_tracks(ndim=3, with_seg=False, is_solution=True)
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    export_to_geff(tracks, run_dir, save_segmentation=False)
+
+    # Corrupt the FeatureDict in GEFF metadata
+    geff_path = run_dir / "tracks.geff"
+    z = zarr.open(str(geff_path), mode="r+")
+    attrs = dict(z.attrs)
+    geff_attrs = dict(attrs["geff"])
+    extra = dict(geff_attrs["extra"])
+    # Replace with garbage that will cause FeatureDict.from_json to raise KeyError
+    extra["funtracks"] = {"features": {"not_a_valid_featuredict": True}}
+    geff_attrs["extra"] = extra
+    attrs["geff"] = geff_attrs
+    z.attrs.clear()
+    z.attrs.update(attrs)
+
+    # Should not raise — falls back to auto-detection
+    imported = import_from_geff(geff_path)
+
+    # Verify the import produced a working SolutionTracks with auto-detected features
+    assert imported.features.time_key is not None
+    assert imported.features.position_key is not None
+    assert imported.features.tracklet_key is not None
+    assert set(tracks.graph.node_ids()) == set(imported.graph.node_ids())

--- a/tests/import_export/test_import_from_geff.py
+++ b/tests/import_export/test_import_from_geff.py
@@ -990,7 +990,7 @@ def test_featuredict_survives_geff_roundtrip(tmp_path):
         None,  # pos — special-cased, slot unused
         0.0,  # area
         np.array([0.0, 0.0]),  # ellipse_axis_radii — must be Array(Float64, 2)
-        None,  # track_id — special-cased, slot unused
+        -1,  # track_id
         -1,  # lineage_id
         1,  # solution
         None,  # mask — special-cased, slot unused

--- a/tests/import_export/test_import_from_geff.py
+++ b/tests/import_export/test_import_from_geff.py
@@ -902,3 +902,82 @@ def test_embedded_seg_ellipse_axis_radii_feature_metadata(tmp_path):
         f"ellipse_axis_radii value_names should be ['major_axis', 'minor_axis'], "
         f"got {feat.get('value_names')}"
     )
+
+
+def test_featuredict_survives_geff_roundtrip(tmp_path):
+    """The FeatureDict stored in GEFF extra metadata must be loaded on import,
+    not re-derived by auto-detection.
+
+    Proves the loaded FeatureDict is the source of truth by customizing a
+    feature's display_name before export — auto-detection would reset it to the
+    default, so a surviving custom value can only come from the stored dict.
+    """
+    import tracksdata as td
+
+    node_attributes = [
+        "pos",
+        "area",
+        "ellipse_axis_radii",
+        "track_id",
+        "lineage_id",
+        "solution",
+        td.DEFAULT_ATTR_KEYS.MASK,
+        td.DEFAULT_ATTR_KEYS.BBOX,
+    ]
+    node_default_values = [
+        None,  # pos — special-cased, slot unused
+        0.0,  # area
+        np.array([0.0, 0.0]),  # ellipse_axis_radii — must be Array(Float64, 2)
+        None,  # track_id — special-cased, slot unused
+        -1,  # lineage_id
+        1,  # solution
+        None,  # mask — special-cased, slot unused
+        None,  # bbox — special-cased, slot unused
+    ]
+    graph = create_empty_graphview_graph(
+        node_attributes=node_attributes,
+        node_default_values=node_default_values,
+        edge_attributes=[],
+        ndim=3,
+    )
+    bbox = [20, 20, 50, 60]
+    graph.bulk_add_nodes(
+        nodes=[
+            {
+                "t": 0,
+                "pos": np.array([35.0, 40.0]),
+                "area": 900.0,
+                "ellipse_axis_radii": np.array([20.0, 15.0]),
+                "track_id": 1,
+                "lineage_id": 1,
+                "solution": 1,
+                td.DEFAULT_ATTR_KEYS.MASK: _make_mask(bbox),
+                td.DEFAULT_ATTR_KEYS.BBOX: np.array(bbox, dtype=np.int64),
+            }
+        ],
+        indices=[1],
+    )
+    graph._update_metadata(segmentation_shape=(3, 100, 100))
+
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+
+    st = SolutionTracks(graph, ndim=3, time_attr="t")
+    # Customize metadata that auto-detection cannot reproduce.
+    pos_key = st.features.position_key
+    assert isinstance(pos_key, str)
+    st.features[pos_key]["display_name"] = "Custom Position Name"
+    export_to_geff(st, run_dir)
+
+    # Import WITHOUT stripping the FeatureDict (the positive path).
+    imported = import_from_geff(run_dir / "tracks.geff")
+
+    assert imported.features[pos_key]["display_name"] == "Custom Position Name", (
+        "Custom display_name should survive the GEFF round-trip, proving the "
+        "stored FeatureDict was loaded rather than re-derived by auto-detection."
+    )
+    # Tracked keys must round-trip too.
+    assert imported.features.time_key == st.features.time_key
+    assert imported.features.position_key == st.features.position_key
+    assert imported.features.tracklet_key == st.features.tracklet_key
+    assert imported.features.lineage_key == st.features.lineage_key

--- a/tests/import_export/test_import_from_geff.py
+++ b/tests/import_export/test_import_from_geff.py
@@ -852,6 +852,31 @@ def test_embedded_seg_ellipse_axis_radii_feature_metadata(tmp_path):
     st = SolutionTracks(graph, ndim=3, time_attr="t")
     export_to_geff(st, run_dir)
 
+    # Remove FeatureDict from GEFF metadata to simulate old/external GEFF
+    # This tests that enable_features() correctly auto-detects features
+    import zarr
+
+    z = zarr.open(str(run_dir / "tracks.geff"), mode="r+")
+    attrs = dict(z.attrs)
+    if "geff" in attrs and "extra" in attrs["geff"]:
+        geff_attrs = dict(attrs["geff"])
+        if "funtracks" in geff_attrs["extra"]:
+            extra = dict(geff_attrs["extra"])
+            if "features" in extra.get("funtracks", {}):
+                funtracks = dict(extra["funtracks"])
+                del funtracks["features"]
+                if not funtracks:
+                    del extra["funtracks"]
+                else:
+                    extra["funtracks"] = funtracks
+                if not extra:
+                    del geff_attrs["extra"]
+                else:
+                    geff_attrs["extra"] = extra
+                attrs["geff"] = geff_attrs
+                z.attrs.clear()
+                z.attrs.update(attrs)
+
     imported = import_from_geff(run_dir / "tracks.geff")
 
     assert any(isinstance(a, RegionpropsAnnotator) for a in imported.annotators), (


### PR DESCRIPTION
Export:
- Save FeatureDict in metadata.extra['funtracks']['features']

Import:
- Load FeatureDict from GEFF metadata if present
- Pass to SolutionTracks constructor instead of manually enabling features
- Falls back gracefully if FeatureDict is missing (backward compatibility)

This preserves feature metadata (types, display names, derived features) across GEFF export/import, enabling future multi-segmentation support.