### PR TITLE
Exclusively export segmentation labels part of the subgraph when node_ids is not None

### DIFF
--- a/src/funtracks/import_export/_export_segmentation.py
+++ b/src/funtracks/import_export/_export_segmentation.py
@@ -80,7 +80,7 @@ def export_segmentation(
         zarr_format: Zarr format version. Only used when file_format="zarr".
             Defaults to 2.
         node_ids: Optional subset of node IDs to include. Cells not in this set
-            are painted as 0 (background). Has no effect when relabel is None.
+            are painted as 0 (background).
 
     Raises:
         ValueError: If tracks.segmentation is None.

--- a/src/funtracks/import_export/_export_segmentation.py
+++ b/src/funtracks/import_export/_export_segmentation.py
@@ -95,18 +95,30 @@ def export_segmentation(
 
     shape = tracks.segmentation.shape
 
+    graph = (
+        tracks.graph.filter(node_ids=list(node_ids)).subgraph()
+        if node_ids is not None
+        else tracks.graph
+    )
+
     if label_attr is not None:
-        graph = (
-            tracks.graph.filter(node_ids=list(node_ids)).subgraph()
-            if node_ids is not None
-            else tracks.graph
-        )
         view = GraphArrayView(graph, label_attr, shape=shape)
 
         def get_frame(t: int) -> np.ndarray:
             return np.array(view[t])
 
         dtype = view.dtype
+
+    elif node_ids is not None:
+        seg = tracks.segmentation
+        allowed = np.array(list(node_ids))
+
+        def get_frame(t: int) -> np.ndarray:
+            frame = np.array(seg[t])
+            return np.where(np.isin(frame, allowed), frame, 0)
+
+        dtype = seg.dtype
+
     else:
         seg = tracks.segmentation
 

--- a/src/funtracks/import_export/csv/_export.py
+++ b/src/funtracks/import_export/csv/_export.py
@@ -155,14 +155,14 @@ def export_to_csv(
 
     # Determine which nodes to export
     if node_ids is None:
-        node_to_keep = tracks.graph.node_ids()
+        nodes_to_keep = tracks.graph.node_ids()
     else:
-        node_to_keep = filter_graph_with_ancestors(tracks.graph, node_ids)
+        nodes_to_keep = filter_graph_with_ancestors(tracks.graph, node_ids)
 
     # Write CSV file
     rows: list[dict[str, Any]] = []
 
-    for node_id in node_to_keep:
+    for node_id in nodes_to_keep:
         parents = list(tracks.graph.predecessors(node_id))
         parent_id = "" if len(parents) == 0 else parents[0]
 
@@ -235,4 +235,5 @@ def export_to_csv(
             file_format=seg_file_format,
             relabel=seg_relabel,
             zarr_format=zarr_format,
+            node_ids=nodes_to_keep,
         )

--- a/tests/import_export/test_csv_export.py
+++ b/tests/import_export/test_csv_export.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pytest
 import tifffile
 import zarr
@@ -191,3 +192,89 @@ def test_ignore_edge_features_at_export(get_tracks, tmp_path):
 
     assert "Area" in lines[0]
     assert "IoU" not in lines[0]
+
+
+@pytest.mark.parametrize("seg_relabel", ["tracklet", "lineage", None])
+@pytest.mark.parametrize("seg_file_format", ["zarr", "tiff"])
+def test_export_solution_to_csv_with_seg_and_node_subset(
+    get_tracks,
+    tmp_path,
+    seg_relabel,
+    seg_file_format,
+):
+    """
+    Test CSV export with segmentation + node subset filtering.
+
+    node_ids passed to export_to_csv are expanded (including ancestors),
+    and segmentation must only include the resulting graph nodes, and nothing else.
+    """
+
+    tracks = get_tracks(ndim=3, with_seg=True, is_solution=True)
+
+    csv_file = tmp_path / "export.csv"
+    seg_path = tmp_path / "seg"
+
+    export_to_csv(
+        tracks,
+        csv_file,
+        node_ids={4, 6},
+        export_seg=True,
+        seg_path=seg_path,
+        seg_file_format=seg_file_format,
+        seg_relabel=seg_relabel,
+    )
+
+    # 1. Validate CSV node export
+    with open(csv_file) as f:
+        lines = f.readlines()
+
+    assert len(lines) >= 2  # header + at least 1 row
+
+    header = lines[0].strip().split(",")
+    assert "id" in header
+
+    exported_ids = {int(line.split(",")[header.index("id")]) for line in lines[1:]}
+
+    # CSV should include expanded graph nodes (NOT just requested subset)
+    expected_graph_nodes = {1, 3, 4, 6}
+    assert exported_ids == expected_graph_nodes
+
+    # 2. Validate segmentation
+    if seg_file_format == "zarr":
+        seg = zarr.open(str(seg_path), mode="r")
+        seg_arr = np.asarray(seg[:])
+    else:
+        seg_arr = tifffile.imread(str(seg_path))
+
+    assert seg_arr.shape == tracks.segmentation.shape
+
+    unique_vals = set(seg_arr.flatten()) - {0}
+
+    original = np.asarray(tracks.segmentation[:])
+
+    graph_nodes = expected_graph_nodes
+
+    if seg_relabel is None:
+        expected = np.where(np.isin(original, list(graph_nodes)), original, 0)
+
+        np.testing.assert_array_equal(seg_arr, expected)
+        assert unique_vals == graph_nodes
+
+    else:
+        if seg_relabel == "lineage":
+            label_key = tracks.features.lineage_key
+        else:
+            label_key = tracks.features.tracklet_key
+
+        labels = tracks.graph.node_attrs(attr_keys=[label_key])[label_key].to_list()
+        node_to_label = dict(zip(tracks.graph.node_ids(), labels, strict=True))
+
+        expected = np.zeros_like(original)
+
+        for n in graph_nodes:
+            expected[original == n] = node_to_label[n]
+
+        np.testing.assert_array_equal(seg_arr, expected)
+
+        expected_vals = {node_to_label[n] for n in graph_nodes}
+        assert unique_vals == expected_vals

--- a/tests/import_export/test_export_to_geff.py
+++ b/tests/import_export/test_export_to_geff.py
@@ -183,8 +183,10 @@ def test_export_to_geff(
     assert isinstance(z, zarr.Group)
 
     node_ids_array = z["nodes/ids"][:]
-    assert np.array_equal(np.sort(node_ids_array), np.array([1, 3, 4, 6])), (
-        f"Unexpected node IDs: found {node_ids_array}, expected {[1, 3, 4, 6]}"
+    expected_graph_nodes = np.array([1, 3, 4, 6])
+
+    assert np.array_equal(np.sort(node_ids_array), expected_graph_nodes), (
+        f"Unexpected node IDs: found {node_ids_array}, expected {expected_graph_nodes}"
     )
 
     seg_path = export_dir / "segmentation"
@@ -192,18 +194,44 @@ def test_export_to_geff(
         seg_zarr = zarr.open(str(seg_path), mode="r")
         assert isinstance(seg_zarr, zarr.Array)
         assert seg_zarr.shape == tracks.segmentation.shape
-        if seg_relabel is not None:
+
+        exported = np.asarray(seg_zarr[:])
+        original = np.asarray(tracks.segmentation[:])
+
+        # segmentation must include ALL nodes in exported graph (including ancestors)
+        graph_nodes = set(expected_graph_nodes)
+
+        if seg_relabel is None:
+            # identity labeling case
+            expected = np.where(np.isin(original, list(graph_nodes)), original, 0)
+            np.testing.assert_array_equal(exported, expected)
+
+            assert set(exported.flatten()) - {0} == graph_nodes
+
+        else:
             if seg_relabel == "lineage":
                 label_key = tracks.features.lineage_key
             else:
                 label_key = tracks.features.tracklet_key
-            kept_vals = set(
-                tracks.graph.filter(node_ids=[1, 3, 4, 6])
-                .node_attrs(attr_keys=[label_key])[label_key]
-                .to_list()
+
+            labels = tracks.graph.node_attrs(attr_keys=[label_key])[label_key]
+
+            node_to_label = dict(
+                zip(tracks.graph.node_ids(), labels.to_list(), strict=True)
             )
-            unique_vals = set(seg_zarr[:].flatten()) - {0}
-            assert unique_vals == kept_vals
+
+            # build expected segmentation from full graph node set
+            expected = np.zeros_like(original)
+
+            for n in graph_nodes:
+                expected[original == n] = node_to_label[n]
+
+            np.testing.assert_array_equal(exported, expected)
+
+            # verify all graph node labels appear in output
+            unique_vals = set(exported.flatten()) - {0}
+            expected_vals = {node_to_label[n] for n in graph_nodes}
+            assert unique_vals == expected_vals
     else:
         assert not seg_path.exists()
 


### PR DESCRIPTION
Only export the segmentation labels for the nodes in the subgraph, regardless of relabeling.

Closes https://github.com/funkelab/funtracks/issues/237