### PR TITLE
Fix solution attr corruption during editing and loading

### DIFF
--- a/src/funtracks/actions/add_delete_edge.py
+++ b/src/funtracks/actions/add_delete_edge.py
@@ -62,7 +62,11 @@ class AddEdge(BasicAction):
         schemas = self.tracks.graph._edge_attr_schemas()
         for attr in self.tracks.graph.edge_attr_keys():
             if attr not in attrs:
-                attrs[attr] = schemas[attr].default_value
+                # An edge added to a Tracks graph is by definition part of the
+                # solution, so default `solution` to True rather than the schema
+                # default, which can be wrong (e.g. Float64/0.0) on graphs loaded
+                # from geff. An explicit caller-provided value still wins.
+                attrs[attr] = True if attr == "solution" else schemas[attr].default_value
 
         # Create edge attributes for this specific edge
         self.tracks.graph.add_edge(

--- a/src/funtracks/actions/add_delete_node.py
+++ b/src/funtracks/actions/add_delete_node.py
@@ -77,9 +77,13 @@ class AddNode(BasicAction):
 
     def _apply(self) -> None:
         """Add the node with all attributes from self.attributes."""
-        self.tracks.graph.add_node(
-            attrs=dict(self.attributes), index=self.node, validate_keys=False
-        )
+        attrs = dict(self.attributes)
+        # A node added to a Tracks graph is by definition part of the solution,
+        # so default `solution` to True rather than the column schema default,
+        # which can be wrong on graphs loaded from geff. An explicit
+        # caller-provided value still wins.
+        attrs.setdefault("solution", True)
+        self.tracks.graph.add_node(attrs=attrs, index=self.node, validate_keys=False)
 
         # Always notify annotators - they will check their own preconditions
         self.tracks.notify_annotators(self)

--- a/src/funtracks/import_export/_tracks_builder.py
+++ b/src/funtracks/import_export/_tracks_builder.py
@@ -506,6 +506,9 @@ class TracksBuilder(ABC):
             for key in graph.node_attr_keys():
                 if key not in node_attr:
                     node_attr[key] = None  # type: ignore[assignment]
+            # `solution` is a Boolean attr; geff may serialise it as float (0.0/1.0).
+            if node_attr.get("solution") is not None:
+                node_attr["solution"] = bool(node_attr["solution"])
             node_attrs.append(node_attr)
 
         edge_attrs = []
@@ -522,6 +525,9 @@ class TracksBuilder(ABC):
             for key in graph.edge_attr_keys():
                 if key not in edge_attr:
                     edge_attr[key] = None  # type: ignore[assignment]
+            # `solution` is a Boolean attr; geff may serialise it as float (0.0/1.0).
+            if edge_attr.get("solution") is not None:
+                edge_attr["solution"] = bool(edge_attr["solution"])
             edge_attrs.append(edge_attr)
 
         graph.bulk_add_nodes(nodes=node_attrs, indices=node_ids)

--- a/src/funtracks/utils/tracksdata_utils.py
+++ b/src/funtracks/utils/tracksdata_utils.py
@@ -158,7 +158,9 @@ def create_empty_graphview_graph(
         graph_td.add_node_attr_key("tracklet_id", default_value=-1, dtype=pl.Int64)
 
     for attr in node_attributes or []:
-        if attr not in graph_td.node_attr_keys():
+        # `solution` is handled by the dedicated Boolean/True branch below; never
+        # let the generic loop register it (e.g. as Float64/0.0 from a geff import).
+        if attr != "solution" and attr not in graph_td.node_attr_keys():
             default_value = node_default_values[(node_attributes or []).index(attr)]
             graph_td.add_node_attr_key(
                 attr,
@@ -171,7 +173,9 @@ def create_empty_graphview_graph(
             )
 
     for attr in edge_attributes or []:
-        if attr not in graph_td.edge_attr_keys():
+        # `solution` is handled by the dedicated Boolean/True branch below; never
+        # let the generic loop register it (e.g. as Float64/0.0 from a geff import).
+        if attr != "solution" and attr not in graph_td.edge_attr_keys():
             default_value = edge_default_values[(edge_attributes or []).index(attr)]
             graph_td.add_edge_attr_key(
                 attr,

--- a/tests/import_export/test_import_from_geff.py
+++ b/tests/import_export/test_import_from_geff.py
@@ -992,7 +992,7 @@ def test_featuredict_survives_geff_roundtrip(tmp_path):
         np.array([0.0, 0.0]),  # ellipse_axis_radii — must be Array(Float64, 2)
         -1,  # track_id
         -1,  # lineage_id
-        1,  # solution
+        True,  # solution — always registered as Boolean
         None,  # mask — special-cased, slot unused
         None,  # bbox — special-cased, slot unused
     ]
@@ -1012,7 +1012,7 @@ def test_featuredict_survives_geff_roundtrip(tmp_path):
                 "ellipse_axis_radii": np.array([20.0, 15.0]),
                 "track_id": 1,
                 "lineage_id": 1,
-                "solution": 1,
+                "solution": True,
                 td.DEFAULT_ATTR_KEYS.MASK: _make_mask(bbox),
                 td.DEFAULT_ATTR_KEYS.BBOX: np.array(bbox, dtype=np.int64),
             }

--- a/tests/import_export/test_solution_roundtrip.py
+++ b/tests/import_export/test_solution_roundtrip.py
@@ -1,0 +1,78 @@
+"""Regression tests for the solution-flag corruption found via motile_tracker.
+
+Covers:
+- AddEdge marks new edges solution=True even when the schema default is wrong.
+- geff round-trip preserves the solution schema as Boolean with default True.
+"""
+
+import numpy as np
+import polars as pl
+
+from funtracks.actions.add_delete_edge import AddEdge
+from funtracks.actions.add_delete_node import AddNode
+from funtracks.import_export import export_to_geff, import_from_geff
+
+
+def _roundtrip(tracks, tmp_path, name="rt.geff"):
+    out = tmp_path / name
+    export_to_geff(tracks, out, overwrite=True)
+    return import_from_geff(out / "tracks.geff")
+
+
+def test_geff_roundtrip_preserves_solution_schema(get_tracks, tmp_path):
+    tracks = get_tracks(ndim=3, with_seg=True, is_solution=True)
+    loaded = _roundtrip(tracks, tmp_path)
+
+    edge_schema = loaded.graph._edge_attr_schemas()["solution"]
+    node_schema = loaded.graph._node_attr_schemas()["solution"]
+
+    assert edge_schema.dtype == pl.Boolean
+    assert edge_schema.default_value is True
+    assert node_schema.dtype == pl.Boolean
+    assert node_schema.default_value is True
+
+
+def test_add_edge_is_solution_true_after_geff_roundtrip(get_tracks, tmp_path):
+    tracks = get_tracks(ndim=3, with_seg=True, is_solution=True)
+    loaded = _roundtrip(tracks, tmp_path)
+    g = loaded.graph
+
+    # find any source at frame t and target at t+1 with no edge between them
+    rows = list(g.node_attrs(attr_keys=["node_id", "t"]).sort("t").iter_rows(named=True))
+    by_t: dict[int, list[int]] = {}
+    for r in rows:
+        by_t.setdefault(r["t"], []).append(r["node_id"])
+    src = tgt = None
+    for t in sorted(by_t):
+        if t + 1 in by_t:
+            for s in by_t[t]:
+                for d in by_t[t + 1]:
+                    if not g.has_edge(s, d):
+                        src, tgt = s, d
+                        break
+                if src is not None:
+                    break
+        if src is not None:
+            break
+    assert src is not None, "fixture has no addable edge"
+
+    AddEdge(loaded, (src, tgt))
+    assert loaded.get_edge_attr((src, tgt), "solution") is True
+
+
+def test_add_node_is_solution_true_after_geff_roundtrip(get_tracks, tmp_path):
+    tracks = get_tracks(ndim=3, with_seg=False, is_solution=True)
+    loaded = _roundtrip(tracks, tmp_path)
+
+    new_id = max(loaded.graph.node_ids()) + 1
+    AddNode(
+        loaded,
+        new_id,
+        {
+            "t": 0,
+            "track_id": 999,
+            "lineage_id": 999,
+            "pos": np.array([1.0, 2.0]),
+        },
+    )
+    assert loaded.get_node_attr(new_id, "solution") is True


### PR DESCRIPTION
Ensure `solution=True` for adding edges|nodes, and make sure `solution` attr stays a bool during loading

Changes: 
- geff round-trip downgraded the solution schema (edge→Float64/0.0, node→Boolean/False). Fixed `create_empty_graphview_graph` so solution always registers as Boolean/True, + coerce imported values to bool in construct_graph.
- AddEdge/AddNode defaulted solution from the (now-wrong) schema default. Added explicit solution=True default in both so a user-added edge/node is always in the solution.
