### PR TITLE
Refactor geff export to work for internal save as well

### DIFF
--- a/src/funtracks/import_export/__init__.py
+++ b/src/funtracks/import_export/__init__.py
@@ -2,7 +2,7 @@ from ._tracks_builder import TracksBuilder
 from ._v1_format import load_v1_tracks
 from .csv._export import export_to_csv
 from .csv._import import CSVTracksBuilder, tracks_from_df
-from .geff._export import export_to_geff
+from .geff._export import export_to_geff, write_to_geff
 from .geff._import import GeffTracksBuilder, import_from_geff
 from .magic_imread import magic_imread
 
@@ -14,6 +14,7 @@ __all__ = [
     "tracks_from_df",
     "export_to_csv",
     "export_to_geff",
+    "write_to_geff",
     "load_v1_tracks",
     "magic_imread",
 ]

--- a/src/funtracks/import_export/geff/_export.py
+++ b/src/funtracks/import_export/geff/_export.py
@@ -151,12 +151,11 @@ def _build_geff_metadata(
     if axis_names is None:
         axis_names = []
     axis_names.insert(0, tracks.features.time_key)
-    if axis_names is not None:
-        axis_types = (
-            ["time", "space", "space"]
-            if tracks.ndim == 3
-            else ["time", "space", "space", "space"]
-        )
+    axis_types = (
+        ["time", "space", "space"]
+        if tracks.ndim == 3
+        else ["time", "space", "space", "space"]
+    )
     if tracks.scale is None:
         tracks.scale = (1.0,) * tracks.ndim
 

--- a/src/funtracks/import_export/geff/_export.py
+++ b/src/funtracks/import_export/geff/_export.py
@@ -21,6 +21,38 @@ if TYPE_CHECKING:
     from funtracks.data_model.tracks import Tracks
 
 
+def write_to_geff(
+    tracks: Tracks,
+    path: Path,
+    overwrite: bool = False,
+    zarr_format: Literal[2, 3] = 2,
+):
+    """Write tracks directly to a geff store at the given path.
+
+    Unlike :func:`export_to_geff` (which creates a parent zarr container with
+    a ``tracks.geff`` subfolder and optional segmentation), this writes the
+    geff store directly to *path*.  Intended for internal save/load workflows
+    where the user picks the ``.geff`` path.
+
+    Args:
+        tracks: Tracks object containing a graph to save.
+        path: Destination path for the geff store.
+        overwrite: If True, overwrites an existing store at *path*.
+        zarr_format: Zarr format version to use. Defaults to 2.
+    """
+    path = remove_tilde(path)
+    path = path.resolve(strict=False)
+
+    graph, metadata = _build_geff_metadata(tracks, include_features=True)
+    graph.to_geff(
+        geff_store=path,
+        geff_metadata=metadata,
+        zarr_format=zarr_format,
+        overwrite=overwrite,
+    )
+    _write_segmentation_shape(path, tracks)
+
+
 def export_to_geff(
     tracks: Tracks,
     directory: Path,
@@ -64,47 +96,10 @@ def export_to_geff(
     mode: Literal["w", "w-"] = "w" if overwrite else "w-"
     setup_zarr_group(directory, zarr_format=zarr_format, mode=mode)
 
-    # update the graph to split the position into separate attrs, if they are currently
-    # together in a list
-    graph, axis_names = split_position_attr(tracks)
-    if axis_names is None:
-        axis_names = []
-    axis_names.insert(0, tracks.features.time_key)
-    if axis_names is not None:
-        axis_types = (
-            ["time", "space", "space"]
-            if tracks.ndim == 3
-            else ["time", "space", "space", "space"]
-        )
-    if tracks.scale is None:
-        tracks.scale = (1.0,) * tracks.ndim
-
-    # Create axes metadata
-    axes = []
-    for name, axis_type, scale in zip(axis_names, axis_types, tracks.scale, strict=True):
-        axes.append(
-            {
-                "name": name,
-                "type": axis_type,
-                "scale": scale,
-            }
-        )
-
     # Include the FeatureDict in metadata only for full exports.
-    # Subgroup exports do not necessarily have valid tracklet/lineage IDs are no
+    # Subgroup exports do not necessarily have valid tracklet/lineage IDs
     # and thus are not valid SolutionTracks
-    extra: dict = {}
-    if node_ids is None:
-        extra["funtracks"] = {"features": tracks.features.dump_json()}
-
-    metadata = GeffMetadata(
-        geff_version=geff_spec.__version__,
-        directed=True,
-        node_props_metadata={},
-        edge_props_metadata={},
-        axes=axes,
-        extra=extra,
-    )
+    graph, metadata = _build_geff_metadata(tracks, include_features=(node_ids is None))
 
     # Save segmentation if present and requested
     if save_segmentation and tracks.segmentation is not None:
@@ -138,15 +133,72 @@ def export_to_geff(
     tracks_path = directory / "tracks.geff"
     graph.to_geff(geff_store=tracks_path, geff_metadata=metadata, zarr_format=zarr_format)
 
-    # Write segmentation_shape as an extra zarr attribute when masks are present.
-    # GeffMetadata has no segmentation_shape field, so it must be stored separately.
-    # This allows import_from_geff to reconstruct the segmentation (GraphArrayView)
-    # without requiring an external segmentation file.
+    _write_segmentation_shape(tracks_path, tracks)
+
+
+def _build_geff_metadata(
+    tracks: Tracks,
+    include_features: bool = True,
+) -> tuple[td.graph.GraphView, GeffMetadata]:
+    """Build the geff metadata and prepare the graph for writing.
+
+    Returns the (possibly modified) graph with split position attributes
+    and the GeffMetadata object.
+    """
+    # update the graph to split the position into separate attrs, if they are currently
+    # together in a list
+    graph, axis_names = split_position_attr(tracks)
+    if axis_names is None:
+        axis_names = []
+    axis_names.insert(0, tracks.features.time_key)
+    if axis_names is not None:
+        axis_types = (
+            ["time", "space", "space"]
+            if tracks.ndim == 3
+            else ["time", "space", "space", "space"]
+        )
+    if tracks.scale is None:
+        tracks.scale = (1.0,) * tracks.ndim
+
+    # Create axes metadata
+    axes = []
+    for name, axis_type, scale in zip(axis_names, axis_types, tracks.scale, strict=True):
+        axes.append(
+            {
+                "name": name,
+                "type": axis_type,
+                "scale": scale,
+            }
+        )
+
+    extra: dict = {}
+    if include_features:
+        extra["funtracks"] = {"features": tracks.features.dump_json()}
+
+    metadata = GeffMetadata(
+        geff_version=geff_spec.__version__,
+        directed=True,
+        node_props_metadata={},
+        edge_props_metadata={},
+        axes=axes,
+        extra=extra,
+    )
+
+    return graph, metadata
+
+
+def _write_segmentation_shape(geff_path: Path, tracks: Tracks) -> None:
+    """Write segmentation_shape as an extra zarr attribute when masks are present.
+
+    GeffMetadata has no segmentation_shape field, so it must be stored separately.
+    This allows import_from_geff to reconstruct the segmentation (GraphArrayView)
+    without requiring an external segmentation file.
+    """
     seg_shape = tracks.graph.metadata.get("segmentation_shape")
     if seg_shape is not None:
         import zarr as _zarr
 
-        z = _zarr.open(str(tracks_path), mode="a")
+        z = _zarr.open(str(geff_path), mode="a")
         attrs = dict(z.attrs)
         attrs["segmentation_shape"] = list(seg_shape)
         z.attrs.update(attrs)

--- a/tests/import_export/test_export_to_geff.py
+++ b/tests/import_export/test_export_to_geff.py
@@ -5,7 +5,7 @@ import tifffile
 import zarr
 
 from funtracks.data_model import SolutionTracks, Tracks
-from funtracks.import_export import export_to_geff
+from funtracks.import_export import export_to_geff, import_from_geff, write_to_geff
 
 
 def _assert_valid_geff_export(export_dir, expected_num_nodes=None):
@@ -351,3 +351,94 @@ def test_export_to_geff_seg_tiff(get_tracks, ndim, tmp_path):
     z = zarr.open((export_dir / "tracks.geff").as_posix(), mode="r")
     related = dict(z.attrs)["geff"].get("related_objects", [])
     assert any(obj["path"] == "../../segmentation.tif" for obj in related)
+
+
+# --- write_to_geff ---
+
+
+@pytest.mark.parametrize("ndim", [3, 4])
+def test_write_to_geff_roundtrip(get_tracks, ndim, tmp_path):
+    """write_to_geff then import_from_geff recovers the tracks."""
+    tracks = get_tracks(ndim=ndim, with_seg=False, is_solution=True)
+
+    geff_path = tmp_path / "my_tracks.geff"
+    write_to_geff(tracks, geff_path)
+
+    loaded = import_from_geff(geff_path)
+
+    assert loaded.graph.num_nodes() == tracks.graph.num_nodes()
+    assert loaded.graph.num_edges() == tracks.graph.num_edges()
+    assert set(loaded.graph.node_ids()) == set(tracks.graph.node_ids())
+    assert loaded.features.dump_json() == tracks.features.dump_json()
+
+
+def test_write_to_geff_no_parent_container(get_tracks, tmp_path):
+    """write_to_geff writes directly to the path — no parent .zgroup or
+    tracks.geff subfolder."""
+    tracks = get_tracks(ndim=3, with_seg=False, is_solution=True)
+
+    geff_path = tmp_path / "my_tracks.geff"
+    write_to_geff(tracks, geff_path)
+
+    # The store is at the given path, not nested inside it
+    z = zarr.open(str(geff_path), mode="r")
+    assert "geff" in dict(z.attrs)
+    assert "nodes" in z
+
+    # No .zgroup/.zattrs at the parent level (tmp_path is not a zarr group)
+    assert not (tmp_path / ".zgroup").exists()
+    assert not (tmp_path / ".zattrs").exists()
+
+
+def test_write_to_geff_overwrite(get_tracks, tmp_path):
+    """write_to_geff with overwrite=True replaces existing store."""
+    tracks = get_tracks(ndim=3, with_seg=False, is_solution=True)
+
+    geff_path = tmp_path / "my_tracks.geff"
+    write_to_geff(tracks, geff_path)
+    write_to_geff(tracks, geff_path, overwrite=True)
+
+    loaded = import_from_geff(geff_path)
+    assert loaded.graph.num_nodes() == tracks.graph.num_nodes()
+
+
+def test_write_to_geff_no_overwrite_raises(get_tracks, tmp_path):
+    """write_to_geff with overwrite=False raises on existing store."""
+    tracks = get_tracks(ndim=3, with_seg=False, is_solution=True)
+
+    geff_path = tmp_path / "my_tracks.geff"
+    write_to_geff(tracks, geff_path)
+
+    with pytest.raises(FileExistsError):
+        write_to_geff(tracks, geff_path, overwrite=False)
+
+
+def test_write_to_geff_metadata(get_tracks, tmp_path):
+    """write_to_geff stores axes and FeatureDict metadata."""
+    tracks = get_tracks(ndim=3, with_seg=False, is_solution=True)
+
+    geff_path = tmp_path / "my_tracks.geff"
+    write_to_geff(tracks, geff_path)
+
+    z = zarr.open(str(geff_path), mode="r")
+    attrs = dict(z.attrs)
+
+    axes = attrs["geff"]["axes"]
+    assert len(axes) == 3
+    assert [ax["type"] for ax in axes] == ["time", "space", "space"]
+
+    assert "funtracks" in attrs["geff"].get("extra", {})
+    assert "features" in attrs["geff"]["extra"]["funtracks"]
+
+
+def test_write_to_geff_segmentation_shape(get_tracks, tmp_path):
+    """write_to_geff writes segmentation_shape when masks are present."""
+    tracks = get_tracks(ndim=3, with_seg=True, is_solution=True)
+
+    geff_path = tmp_path / "my_tracks.geff"
+    write_to_geff(tracks, geff_path)
+
+    z = zarr.open(str(geff_path), mode="r")
+    attrs = dict(z.attrs)
+    assert "segmentation_shape" in attrs
+    assert tuple(attrs["segmentation_shape"]) == tracks.segmentation.shape

--- a/tests/import_export/test_export_to_geff.py
+++ b/tests/import_export/test_export_to_geff.py
@@ -357,9 +357,10 @@ def test_export_to_geff_seg_tiff(get_tracks, ndim, tmp_path):
 
 
 @pytest.mark.parametrize("ndim", [3, 4])
-def test_write_to_geff_roundtrip(get_tracks, ndim, tmp_path):
+@pytest.mark.parametrize("with_seg", [False, True])
+def test_write_to_geff_roundtrip(get_tracks, ndim, with_seg, tmp_path):
     """write_to_geff then import_from_geff recovers the tracks."""
-    tracks = get_tracks(ndim=ndim, with_seg=False, is_solution=True)
+    tracks = get_tracks(ndim=ndim, with_seg=with_seg, is_solution=True)
 
     geff_path = tmp_path / "my_tracks.geff"
     write_to_geff(tracks, geff_path)
@@ -370,6 +371,13 @@ def test_write_to_geff_roundtrip(get_tracks, ndim, tmp_path):
     assert loaded.graph.num_edges() == tracks.graph.num_edges()
     assert set(loaded.graph.node_ids()) == set(tracks.graph.node_ids())
     assert loaded.features.dump_json() == tracks.features.dump_json()
+
+    if with_seg:
+        assert loaded.segmentation is not None
+        assert loaded.segmentation.shape == tracks.segmentation.shape
+        np.testing.assert_array_equal(
+            np.asarray(loaded.segmentation[:]), np.asarray(tracks.segmentation[:])
+        )
 
 
 def test_write_to_geff_no_parent_container(get_tracks, tmp_path):


### PR DESCRIPTION
Add a write_to_geff function that shares helpers with export_to_geff but exports directly to a directory and doesn't save optional segmentation and geff as sub-groups in a parent darr.