### PR TITLE
add solutiontracks benchmark

### DIFF
--- a/tests/benchmarks/bench_candidate_graph.py
+++ b/tests/benchmarks/bench_candidate_graph.py
@@ -9,6 +9,7 @@ import pytest
 from skimage.draw import disk
 
 from funtracks.candidate_graph.compute_graph import compute_graph_from_seg
+from funtracks.data_model import SolutionTracks
 
 NUM_FRAMES = 50
 FRAME_SHAPE = (700, 1100)
@@ -50,3 +51,20 @@ def test_compute_graph_from_seg(benchmark, seg_data):
         rounds=1,
         iterations=1,
     )
+
+
+def test_graph_to_solution(benchmark, seg_data):
+    """Benchmark candidate graph -> SolutionTracks (tracklet/lineage assignment).
+
+    Candidate-graph construction is benchmarked separately above and is built here in
+    (untimed) setup, so only the SolutionTracks construction -- dominated by
+    TrackAnnotator._assign_tracklet_ids and _assign_lineage_ids -- is measured.
+    """
+
+    def setup():
+        # Fresh graph per round: SolutionTracks construction mutates the graph
+        # (adds tracklet/lineage IDs), so each measured call must start unannotated.
+        graph = compute_graph_from_seg(seg_data, MAX_EDGE_DISTANCE, iou=True)
+        return (graph,), {"time_attr": "t", "pos_attr": "pos"}
+
+    benchmark.pedantic(SolutionTracks, setup=setup, rounds=1, iterations=1)


### PR DESCRIPTION
In order to properly benchmark the new (to be pushed) track|lineage_id logic, let's first add a benchmark that actually rusn the cand_graph to SolutionTracks logic, as done here

(will change with the persistence graph PR, but thats a worry for later)