### PR TITLE
faster regionprops annotator

### DIFF
--- a/src/funtracks/annotators/_regionprops_annotator.py
+++ b/src/funtracks/annotators/_regionprops_annotator.py
@@ -31,6 +31,29 @@ DEFAULT_CIRCULARITY_KEY = "circularity"
 DEFAULT_PERIMETER_KEY = "perimeter"
 
 
+def _centroid(mask: Mask, spacing: tuple[float, ...] | None) -> list[float]:
+    """Centroid in world units, read directly from the mask array.
+
+    Equivalent to ``ExtendedRegionProperties.centroid`` (``(local_centroid + bbox_min)
+    * spacing``) but skips the skimage regionprops machinery (find_objects, region
+    caching), which is wasted overhead when only the centroid is needed.
+
+    Args:
+        mask: A Mask object representing one detection.
+        spacing: Voxel spacing per spatial dimension, or None for unit spacing.
+
+    Returns:
+        The centroid coordinates, one float per spatial dimension.
+    """
+    arr = mask.mask
+    bbox_min = mask.bbox[: arr.ndim]
+    local = np.array([idx.mean() for idx in np.nonzero(arr)])
+    world = local + bbox_min
+    if spacing is not None:
+        world = world * np.asarray(spacing)
+    return [float(v) for v in world]
+
+
 class FeatureSpec(NamedTuple):
     """Specification for a regionprops feature.
 
@@ -170,13 +193,23 @@ class RegionpropsAnnotator(GraphAnnotator):
         all_node_ids = []
         all_values: dict[str, list] = {key: [] for key in keys_to_compute}
 
+        # Position (centroid) is the only feature computed at construction. Reading it
+        # via skimage regionprops pays for a find_objects + RegionProperties build per
+        # mask that is wasted when centroid is all we need, so take it straight from the
+        # mask array. Any other features still need the full regionprops pass.
+        want_pos = self.pos_key in keys_to_compute
+        regionprops_keys = [key for key in keys_to_compute if key != self.pos_key]
+
         for node_id in self.tracks.graph.node_ids():
             if not self.tracks.graph.has_node(node_id):
                 continue
             mask = self.tracks.graph.nodes[node_id]["mask"]
-            for region in regionprops_extended(mask, spacing=spacing):
-                all_node_ids.append(node_id)
-                for key in keys_to_compute:
+            all_node_ids.append(node_id)
+            if want_pos:
+                all_values[self.pos_key].append(_centroid(mask, spacing))
+            if regionprops_keys:
+                (region,) = regionprops_extended(mask, spacing=spacing)
+                for key in regionprops_keys:
                     value = getattr(region, self.regionprops_names[key])
                     if isinstance(value, tuple):
                         value = [float(v) for v in value]

--- a/src/funtracks/annotators/_regionprops_annotator.py
+++ b/src/funtracks/annotators/_regionprops_annotator.py
@@ -193,29 +193,30 @@ class RegionpropsAnnotator(GraphAnnotator):
         all_node_ids = []
         all_values: dict[str, list] = {key: [] for key in keys_to_compute}
 
-        # Position (centroid) is the only feature computed at construction. Reading it
-        # via skimage regionprops pays for a find_objects + RegionProperties build per
-        # mask that is wasted when centroid is all we need, so take it straight from the
-        # mask array. Any other features still need the full regionprops pass.
-        want_pos = self.pos_key in keys_to_compute
-        regionprops_keys = [key for key in keys_to_compute if key != self.pos_key]
+        # Position (centroid) is the only feature computed at construction. When it is
+        # the sole requested feature, reading it via skimage regionprops pays for a
+        # find_objects + RegionProperties build per mask that is pure overhead, so take
+        # it straight from the mask array. If any other feature is requested we run the
+        # regionprops pass anyway and its centroid comes for free, so pos goes through
+        # the normal path with everything else.
+        fast_pos = keys_to_compute == [self.pos_key]
 
         for node_id in self.tracks.graph.node_ids():
             if not self.tracks.graph.has_node(node_id):
                 continue
             mask = self.tracks.graph.nodes[node_id]["mask"]
             all_node_ids.append(node_id)
-            if want_pos:
+            if fast_pos:
                 all_values[self.pos_key].append(_centroid(mask, spacing))
-            if regionprops_keys:
-                (region,) = regionprops_extended(mask, spacing=spacing)
-                for key in regionprops_keys:
-                    value = getattr(region, self.regionprops_names[key])
-                    if isinstance(value, tuple):
-                        value = [float(v) for v in value]
-                    elif isinstance(value, np.floating):
-                        value = float(value)
-                    all_values[key].append(value)
+                continue
+            (region,) = regionprops_extended(mask, spacing=spacing)
+            for key in keys_to_compute:
+                value = getattr(region, self.regionprops_names[key])
+                if isinstance(value, tuple):
+                    value = [float(v) for v in value]
+                elif isinstance(value, np.floating):
+                    value = float(value)
+                all_values[key].append(value)
 
         for key in keys_to_compute:
             self.tracks._set_nodes_attr(all_node_ids, key, all_values[key])


### PR DESCRIPTION
In the majority of cases where the `RegionpropsAnnotator` is called, it is only to retrieve the position key (mainly in SolutionTracks.__init__, where the pos key is recomputed). It is overkill to use regionprops for this on every single mask.

This PR implements a faster method to find the position from `mask+bbox` without having to go through the expensive regionprops. 

This path is not part of the current benchmark, but in my hands, it's >3x faster. 